### PR TITLE
[fix] 애플 로그인 시 이름 스킵

### DIFF
--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -54,3 +54,12 @@ export const deleteMyAccount = async () => {
   });
   return response;
 };
+
+export const getSignupPrefill = async (): Promise<{ name: string } | null> => {
+  try {
+    const response = await apiClient.get<{ name: string }>('users/signup/prefill');
+    return response;
+  } catch {
+    return null;
+  }
+};

--- a/src/pages/Auth/SignUp/StudentIdStep.tsx
+++ b/src/pages/Auth/SignUp/StudentIdStep.tsx
@@ -2,16 +2,24 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSignupStore } from '@/stores/signupStore';
 import StepLayout from './components/StepLayout';
+import { useSignupPrefill } from './hooks/useSignupPrefill';
 
 function StudentIdStep() {
   const navigate = useNavigate();
   const { studentId: savedStudentId, update } = useSignupStore();
 
   const [studentId, setStudentId] = useState(savedStudentId ?? '');
+  const { data: prefill, isPending } = useSignupPrefill();
 
   const handleNext = () => {
     update({ studentId });
-    navigate('/signup/name');
+
+    if (prefill?.name) {
+      update({ name: prefill.name });
+      navigate('/signup/confirm');
+    } else {
+      navigate('/signup/name');
+    }
   };
 
   return (
@@ -19,7 +27,7 @@ function StudentIdStep() {
       title="학번을 입력해주세요"
       description={`정확한 답변을 하지 않으면\n불이익이 발생할 수 있습니다.`}
       onNext={handleNext}
-      nextDisabled={!studentId.trim()}
+      nextDisabled={!studentId.trim() || isPending}
     >
       <input
         type="text"

--- a/src/pages/Auth/SignUp/hooks/useSignupPrefill.ts
+++ b/src/pages/Auth/SignUp/hooks/useSignupPrefill.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSignupPrefill } from '@/apis/auth';
+
+export const useSignupPrefill = () => {
+  return useQuery({
+    queryKey: ['signup', 'prefill'],
+    queryFn: getSignupPrefill,
+  });
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원가입 시 사용자 이름이 자동으로 미리 채워집니다. 이름이 이미 등록된 경우 확인 단계로 바로 진행되며, 그렇지 않으면 이름 입력 단계로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->