### PR TITLE
[fix] 홈 화면 툴팁 및 캘린더 레이아웃 개선

### DIFF
--- a/src/components/layout/Header/components/InfoHeader.tsx
+++ b/src/components/layout/Header/components/InfoHeader.tsx
@@ -1,8 +1,11 @@
+import { useLocation } from 'react-router-dom';
 import { useMyInfo } from '@/pages/User/Profile/hooks/useMyInfo';
 import NotificationBell from './NotificationBell';
 
 function InfoHeader() {
+  const { pathname } = useLocation();
   const { myInfo } = useMyInfo();
+  const showChatTooltip = pathname === '/home';
 
   return (
     <header className="fixed top-0 right-0 left-0 z-30 flex items-center rounded-b-3xl bg-white px-4 pt-2 pb-3 shadow-[0_2px_2px_0_rgba(0,0,0,0.05)]">
@@ -12,7 +15,7 @@ function InfoHeader() {
           {myInfo.name} {myInfo.studentNumber}
         </div>
       </div>
-      <NotificationBell />
+      <NotificationBell showTooltip={showChatTooltip} />
     </header>
   );
 }

--- a/src/components/layout/Header/components/NotificationBell.tsx
+++ b/src/components/layout/Header/components/NotificationBell.tsx
@@ -1,19 +1,77 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import ChatCatIcon from '@/assets/svg/chat-cat.svg';
+import MegaphoneSmIcon from '@/assets/svg/megaphone-sm.svg';
 import useChat from '@/pages/Chat/hooks/useChat';
+import { cn } from '@/utils/ts/cn';
 
-function NotificationBell() {
+const CHAT_TOOLTIP_DISMISSED_STORAGE_KEY = 'chat-tooltip-dismissed:v1';
+
+const readChatTooltipDismissed = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(CHAT_TOOLTIP_DISMISSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+interface NotificationBellProps {
+  showTooltip?: boolean;
+}
+
+function NotificationBell({ showTooltip = false }: NotificationBellProps) {
   const { totalUnreadCount } = useChat();
+  const [isTooltipDismissed, setIsTooltipDismissed] = useState(readChatTooltipDismissed);
+
+  const shouldShowTooltip = showTooltip && !isTooltipDismissed;
+
+  const handleChatButtonClick = () => {
+    if (isTooltipDismissed) {
+      return;
+    }
+
+    setIsTooltipDismissed(true);
+
+    try {
+      window.localStorage.setItem(CHAT_TOOLTIP_DISMISSED_STORAGE_KEY, 'true');
+    } catch {
+      // Ignore storage failures and continue navigation.
+    }
+  };
 
   return (
-    <Link to={'chats'} aria-label="채팅 열기" className="relative">
-      <ChatCatIcon />
-      {totalUnreadCount > 0 && (
-        <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] text-white">
-          {totalUnreadCount > 99 ? '99+' : totalUnreadCount}
-        </span>
-      )}
-    </Link>
+    <div className="relative inline-flex">
+      <Link
+        to={'chats'}
+        aria-label="채팅 열기"
+        onClick={handleChatButtonClick}
+        className={cn('relative inline-flex', shouldShowTooltip && 'chat-tooltip-anchor')}
+      >
+        <ChatCatIcon />
+        {totalUnreadCount > 0 ? (
+          <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] text-white">
+            {totalUnreadCount > 99 ? '99+' : totalUnreadCount}
+          </span>
+        ) : null}
+      </Link>
+
+      {shouldShowTooltip ? (
+        <div className="chat-tooltip pointer-events-none absolute top-[calc(100%+6px)] right-0 z-10 w-[149px]">
+          <span
+            className="chat-tooltip-arrow absolute -top-1 right-[15px] h-3 w-3.5 bg-black/40 [clip-path:polygon(50%_0,0_100%,100%_100%)]"
+            aria-hidden
+          />
+          <div className="mt-2 flex items-center gap-1 rounded-[20px] bg-black/40 px-2.5 py-1 text-white">
+            <MegaphoneSmIcon className="text-warning-600 size-[13px] shrink-0" />
+            <span className="text-cap2-strong whitespace-nowrap">채팅방 기능을 사용해보세요!</span>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -234,3 +234,16 @@ input[type="month"]::-webkit-clear-button {
 .touch-pan-y {
   touch-action: pan-y;
 }
+
+.chat-tooltip-anchor {
+  anchor-name: --chat-tooltip-anchor;
+}
+
+@supports (anchor-name: --chat-tooltip-anchor) {
+  .chat-tooltip {
+    position-anchor: --chat-tooltip-anchor;
+    top: calc(anchor(bottom) + 6px);
+    left: calc(anchor(right) - 149px);
+    right: auto;
+  }
+}

--- a/src/pages/Home/components/HomeClubSection.tsx
+++ b/src/pages/Home/components/HomeClubSection.tsx
@@ -110,7 +110,7 @@ function RecruitingClubSection() {
 
   if (clubs.length === 0) {
     return (
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
         <SectionTitle title="나에게 맞는 동아리를 찾아보세요!" to="/clubs" />
         <Card className="gap-2 rounded-[20px] border-0 py-5 shadow-[0_0_3px_rgba(0,0,0,0.2)]">
           <div className="text-h3 text-indigo-700">현재 모집 중인 동아리가 없어요</div>
@@ -139,7 +139,7 @@ function HomeClubSection() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1">
       <SectionTitle title="내 동아리" to="/clubs" />
       <InfiniteClubCarousel clubs={clubs} />
     </div>

--- a/src/pages/Home/components/MiniSchedulePreview.tsx
+++ b/src/pages/Home/components/MiniSchedulePreview.tsx
@@ -56,7 +56,7 @@ function MiniSchedulePreview() {
   };
 
   return (
-    <div className="h-[193px] overflow-hidden rounded-[20px] bg-white px-3 pt-3 shadow-[0_0_3px_rgba(0,0,0,0.2)]">
+    <div className="overflow-hidden rounded-[20px] bg-white px-3 pt-3 shadow-[0_0_3px_rgba(0,0,0,0.2)]">
       <ul className="grid grid-cols-7 justify-items-center text-center text-[13px] leading-5 font-bold text-indigo-600">
         {SCHEDULE_DAYS.map((dayLabel) => (
           <li key={dayLabel}>{dayLabel}</li>

--- a/src/pages/Home/hooks/useInfiniteClubCarousel.ts
+++ b/src/pages/Home/hooks/useInfiniteClubCarousel.ts
@@ -106,12 +106,15 @@ export const useInfiniteClubCarousel = ({ clubs }: UseInfiniteClubCarouselParams
     scrollNode.style.scrollSnapType = 'none';
     scrollNode.scrollLeft = left;
 
+    // scrollLeft 변경을 즉시 레이아웃에 반영(reflow)한 뒤 snap을 동기적으로 복원한다.
+    // 기존 double-rAF 방식은 snap이 꺼진 채 2프레임이 렌더되어,
+    // 복원 시 위치가 snap point와 미세하게 어긋나면 re-snap 애니메이션이 발생했다.
+    void scrollNode.scrollLeft;
+    scrollNode.style.scrollSnapType = '';
+
     restoreSnapFrameRef.current = window.requestAnimationFrame(() => {
-      restoreSnapFrameRef.current = window.requestAnimationFrame(() => {
-        scrollNode.style.scrollSnapType = '';
-        isAdjustingLoopRef.current = false;
-        restoreSnapFrameRef.current = null;
-      });
+      isAdjustingLoopRef.current = false;
+      restoreSnapFrameRef.current = null;
     });
   };
 
@@ -131,15 +134,16 @@ export const useInfiniteClubCarousel = ({ clubs }: UseInfiniteClubCarouselParams
 
     const middleStartIndex = clubs.length;
     const middleEndIndex = clubs.length * 2 - 1;
-    const segmentWidth = getSlideOffset(clubs.length * 2) - getSlideOffset(clubs.length);
-
-    if (segmentWidth <= 0) return;
 
     // 항상 가운데 세그먼트로 되돌려서 무한 루프가 끊기지 않게 유지한다.
-    if (currentIndex < middleStartIndex) {
-      jumpToLoopPosition(scrollNode.scrollLeft + segmentWidth);
-    } else if (currentIndex > middleEndIndex) {
-      jumpToLoopPosition(scrollNode.scrollLeft - segmentWidth);
+    // 상대 offset(scrollLeft ± segmentWidth) 대신 getSlideOffset으로 정확한 snap point를
+    // 직접 계산해 부동소수점 오차로 인한 micro re-snap을 방지한다.
+    if (currentIndex < middleStartIndex || currentIndex > middleEndIndex) {
+      const middleEquivalent = middleStartIndex + (currentIndex % clubs.length);
+      const targetLeft = getSlideOffset(middleEquivalent);
+      if (Math.abs(targetLeft - scrollNode.scrollLeft) > 1) {
+        jumpToLoopPosition(targetLeft);
+      }
     }
   });
 
@@ -148,6 +152,13 @@ export const useInfiniteClubCarousel = ({ clubs }: UseInfiniteClubCarouselParams
 
     const currentIndex = getClosestSlideIndex();
     if (currentIndex === null) return;
+
+    // Edge 세그먼트(첫 번째/세 번째 복제본)에 있을 때는 activeIndex를 업데이트하지 않는다.
+    // 마지막↔첫 번째 경계를 지나는 동안 getClosestSlideIndex()가 두 snap point 사이를
+    // 빠르게 오가며 activeIndex가 토글되어 인디케이터가 플리커링하는 것을 방지한다.
+    if (shouldLoop && (currentIndex < clubs.length || currentIndex >= clubs.length * 2)) {
+      return;
+    }
 
     setCarouselIndex(currentIndex % clubs.length);
   };

--- a/src/pages/Schedule/components/CalendarWeekRow.tsx
+++ b/src/pages/Schedule/components/CalendarWeekRow.tsx
@@ -3,6 +3,10 @@ import { SCHEDULE_COLOR } from '@/constants/schedule';
 import { parseDateDot } from '@/utils/ts/date';
 import DateBox from './DateBox';
 
+const BAR_HEIGHT = 13;
+const BAR_ROW_GAP = 3;
+const MAX_VISIBLE_LANES = 2;
+
 type BarItem = {
   schedule: Schedule;
   startCol: number;
@@ -82,10 +86,10 @@ function CalendarWeekRow({
   onDateClick,
 }: CalendarWeekRowProps) {
   const bars = layoutBars(dates, schedules, isCurrentMonth);
-  const visibleBars = bars.filter((b) => b.lane < 2);
+  const visibleBars = bars.filter((b) => b.lane < MAX_VISIBLE_LANES);
   const overflowMap = new Map<number, number>();
   for (const bar of bars) {
-    if (bar.lane >= 2) {
+    if (bar.lane >= MAX_VISIBLE_LANES) {
       overflowMap.set(bar.startCol, (overflowMap.get(bar.startCol) ?? 0) + 1);
     }
   }
@@ -106,12 +110,12 @@ function CalendarWeekRow({
       </div>
 
       <div
-        className="mb-2"
+        className="mt-0.5 mb-2.5"
         style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(7, 1fr)',
-          gridTemplateRows: '18px 18px auto',
-          rowGap: '2px',
+          gridTemplateRows: `${BAR_HEIGHT}px ${BAR_HEIGHT}px 8px`,
+          rowGap: `${BAR_ROW_GAP}px`,
         }}
       >
         {visibleBars.map((bar) => (
@@ -122,7 +126,7 @@ function CalendarWeekRow({
               gridRow: bar.lane + 1,
               backgroundColor: SCHEDULE_COLOR[bar.schedule.scheduleCategory],
             }}
-            className="text-caption2 h-[18px] truncate rounded-full px-1.5 text-center leading-[18px] font-medium"
+            className="h-[13px] truncate rounded-full px-1 text-center text-[10px] leading-[13px] font-medium text-[#25374C]"
           >
             {bar.schedule.title}
           </div>
@@ -131,8 +135,8 @@ function CalendarWeekRow({
         {[...overflowMap.entries()].map(([col, count]) => (
           <div
             key={`ov-${col}`}
-            style={{ gridColumn: col + 1, gridRow: 3 }}
-            className="text-caption2 pl-1 font-semibold text-indigo-500"
+            style={{ gridColumn: col + 1, gridRow: MAX_VISIBLE_LANES + 1 }}
+            className="pl-1 text-[8px] leading-[8px] font-semibold text-indigo-500"
           >
             +{count}개
           </div>

--- a/src/pages/Schedule/components/DateBox.tsx
+++ b/src/pages/Schedule/components/DateBox.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/utils/ts/cn';
+
 type DateBoxProps = {
   date: Date;
   isCurrentMonth: boolean;
@@ -12,19 +14,16 @@ function DateBox({ date, isCurrentMonth, isSelected, isSunday, onClick }: DateBo
       type="button"
       disabled={!isCurrentMonth}
       onClick={() => onClick(date)}
-      className="flex h-9 w-full items-center justify-center"
+      className="flex h-[35px] w-full items-center justify-center"
     >
       <span
-        className={[
-          'flex h-7 w-7 items-center justify-center text-[12px] leading-5 font-semibold',
-          !isCurrentMonth
-            ? 'text-transparent'
-            : isSelected
-              ? 'rounded-full bg-[#1B2B4B] text-white'
-              : isSunday
-                ? 'text-red-500'
-                : 'text-black',
-        ].join(' ')}
+        className={cn(
+          'flex items-center justify-center text-[12px] leading-[1.6] font-semibold',
+          !isCurrentMonth && 'text-transparent',
+          isCurrentMonth && !isSelected && 'h-4 min-w-4 px-1',
+          isCurrentMonth && isSelected && 'size-5 rounded-full bg-[#1B2B4B] text-white',
+          isCurrentMonth && !isSelected && (isSunday ? 'text-red-500' : 'text-black')
+        )}
       >
         {isCurrentMonth ? date.getDate() : ''}
       </span>


### PR DESCRIPTION
## ✨ 요약

```ts
- 홈 헤더 채팅 버튼에 최초 1회 노출되는 안내 툴팁을 추가했습니다.
- 사용자가 채팅 버튼을 누르면 localStorage 기반으로 툴팁이 다시 보이지 않도록 처리했습니다.
- Anchor Positioning을 지원하는 브라우저에서는 아이콘 기준으로 툴팁 위치를 고정하고, 미지원 환경에는 fallback을 유지했습니다.
- 홈 동아리 캐러셀의 무한 루프 재배치 로직을 보정해 micro re-snap과 인디케이터 플리커링을 줄였습니다.
- 홈 일정 미리보기 캘린더의 날짜/일정 바 높이와 간격을 시안에 맞게 조정했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #180

<br><br>