### PR TITLE
[hotfix] 하단바 너비 수정

### DIFF
--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -36,7 +36,7 @@ function BottomNavItem({ to, label, Icon, end = false }: BottomNavItemConfig) {
 function BottomNav() {
   return (
     <nav className="fixed right-0 bottom-0 left-0 z-20 rounded-[20px] border-t border-[#e0e0e0] bg-white">
-      <div className="flex min-h-[75px] w-full items-center justify-center gap-13 px-7 py-2 text-xs font-semibold">
+      <div className="flex min-h-[75px] w-full items-center justify-around px-7 py-2 text-xs font-semibold">
         {BOTTOM_NAV_ITEMS.map((item) => (
           <BottomNavItem key={item.to} {...item} />
         ))}

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -36,7 +36,7 @@ function BottomNavItem({ to, label, Icon, end = false }: BottomNavItemConfig) {
 function BottomNav() {
   return (
     <nav className="fixed right-0 bottom-0 left-0 z-20 rounded-[20px] border-t border-[#e0e0e0] bg-white">
-      <div className="mx-auto flex min-h-[75px] w-full items-center justify-center gap-13 px-7 py-2 text-xs font-semibold">
+      <div className="flex min-h-[75px] w-full items-center justify-center gap-13 px-7 py-2 text-xs font-semibold">
         {BOTTOM_NAV_ITEMS.map((item) => (
           <BottomNavItem key={item.to} {...item} />
         ))}

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -36,7 +36,7 @@ function BottomNavItem({ to, label, Icon, end = false }: BottomNavItemConfig) {
 function BottomNav() {
   return (
     <nav className="fixed right-0 bottom-0 left-0 z-20 rounded-[20px] border-t border-[#e0e0e0] bg-white">
-      <div className="mx-auto flex min-h-[75px] max-w-md items-center justify-center gap-13 px-7 py-2 text-xs font-semibold">
+      <div className="mx-auto flex min-h-[75px] w-full items-center justify-center gap-13 px-7 py-2 text-xs font-semibold">
         {BOTTOM_NAV_ITEMS.map((item) => (
           <BottomNavItem key={item.to} {...item} />
         ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 하단 네비게이션 바가 화면의 전체 너비를 사용하도록 개선되어, 네비게이션 항목들이 더 넓은 영역에 고르게 배치됩니다. 레이아웃과 간격, 타이포그래피 등 기존 디자인 특성은 유지되어 사용자 경험은 일관되게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->