### PR TITLE
[fix] 모바일 환경 입력창과 키보드 간의 간격이 큰 문제 수정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@
 
   --viewport-height: 100dvh;
   --viewport-offset: 0px;
+  --effective-bottom-safe-area: var(--sab);
 
   --font-suit:
     'SUIT', Roboto, system-ui, 'Segoe UI', Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',

--- a/src/pages/Chat/ChatRoom.tsx
+++ b/src/pages/Chat/ChatRoom.tsx
@@ -186,7 +186,10 @@ function ChatRoom() {
         })}
       </div>
 
-      <form onSubmit={handleSubmit} className="shrink-0 bg-white px-5 pt-3 pb-[calc(22px+var(--sab))]">
+      <form
+        onSubmit={handleSubmit}
+        className="shrink-0 bg-white px-5 pt-3 pb-[calc(12px+var(--effective-bottom-safe-area))]"
+      >
         <div className="bg-text-100 flex min-w-0 items-end gap-3 rounded-[30px] px-4 py-3">
           <textarea
             ref={textareaRef}

--- a/src/utils/ts/viewport.ts
+++ b/src/utils/ts/viewport.ts
@@ -1,12 +1,32 @@
 export function installViewportVars() {
   let scheduled = false;
+  let isEditableFocused = false;
+  let restingViewportHeight = 0;
+
+  const isTextInputElement = (element: EventTarget | null): element is HTMLElement => {
+    if (!(element instanceof HTMLElement)) return false;
+
+    return element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement || element.isContentEditable;
+  };
 
   const setViewportHeight = () => {
     const vv = window.visualViewport;
     const h = vv?.height ?? window.innerHeight;
     const offset = Math.max(0, vv?.offsetTop ?? 0);
-    document.documentElement.style.setProperty('--viewport-height', `${h}px`);
-    document.documentElement.style.setProperty('--viewport-offset', `${offset}px`);
+    const root = document.documentElement;
+
+    if (!isEditableFocused) {
+      restingViewportHeight = h;
+    } else if (!restingViewportHeight) {
+      restingViewportHeight = h;
+    }
+
+    const keyboardHeight = Math.max(0, restingViewportHeight - h);
+    const isKeyboardOpen = isEditableFocused && keyboardHeight > 120;
+
+    root.style.setProperty('--viewport-height', `${h}px`);
+    root.style.setProperty('--viewport-offset', `${offset}px`);
+    root.style.setProperty('--effective-bottom-safe-area', isKeyboardOpen ? '0px' : 'var(--sab)');
   };
 
   const requestSetViewportHeight = () => {
@@ -21,6 +41,18 @@ export function installViewportVars() {
   setViewportHeight();
   requestAnimationFrame(() => requestAnimationFrame(setViewportHeight));
 
+  const handleFocusIn = (event: FocusEvent) => {
+    isEditableFocused = isTextInputElement(event.target);
+    requestSetViewportHeight();
+  };
+
+  const handleFocusOut = (event: FocusEvent) => {
+    if (isTextInputElement(event.target)) {
+      isEditableFocused = false;
+      requestSetViewportHeight();
+    }
+  };
+
   window.addEventListener('resize', requestSetViewportHeight);
   window.addEventListener('orientationchange', requestSetViewportHeight);
   window.addEventListener('pageshow', requestSetViewportHeight);
@@ -28,8 +60,8 @@ export function installViewportVars() {
   window.visualViewport?.addEventListener('resize', requestSetViewportHeight);
   window.visualViewport?.addEventListener('scroll', requestSetViewportHeight);
 
-  window.addEventListener('focusin', requestSetViewportHeight);
-  window.addEventListener('focusout', requestSetViewportHeight);
+  window.addEventListener('focusin', handleFocusIn);
+  window.addEventListener('focusout', handleFocusOut);
 
   return () => {
     window.removeEventListener('resize', requestSetViewportHeight);
@@ -39,7 +71,7 @@ export function installViewportVars() {
     window.visualViewport?.removeEventListener('resize', requestSetViewportHeight);
     window.visualViewport?.removeEventListener('scroll', requestSetViewportHeight);
 
-    window.removeEventListener('focusin', requestSetViewportHeight);
-    window.removeEventListener('focusout', requestSetViewportHeight);
+    window.removeEventListener('focusin', handleFocusIn);
+    window.removeEventListener('focusout', handleFocusOut);
   };
 }

--- a/src/utils/ts/viewport.ts
+++ b/src/utils/ts/viewport.ts
@@ -1,7 +1,10 @@
+const KEYBOARD_OPEN_THRESHOLD_PX = 120;
+
 export function installViewportVars() {
   let scheduled = false;
   let isEditableFocused = false;
   let restingViewportHeight = 0;
+  let restingViewportWidth = 0;
 
   const isTextInputElement = (element: EventTarget | null): element is HTMLElement => {
     if (!(element instanceof HTMLElement)) return false;
@@ -12,17 +15,18 @@ export function installViewportVars() {
   const setViewportHeight = () => {
     const vv = window.visualViewport;
     const h = vv?.height ?? window.innerHeight;
+    const w = vv?.width ?? window.innerWidth;
     const offset = Math.max(0, vv?.offsetTop ?? 0);
     const root = document.documentElement;
+    const hasViewportContextChanged = Math.abs(restingViewportWidth - w) > 80;
 
-    if (!isEditableFocused) {
+    if (!isEditableFocused || !restingViewportHeight || hasViewportContextChanged) {
       restingViewportHeight = h;
-    } else if (!restingViewportHeight) {
-      restingViewportHeight = h;
+      restingViewportWidth = w;
     }
 
     const keyboardHeight = Math.max(0, restingViewportHeight - h);
-    const isKeyboardOpen = isEditableFocused && keyboardHeight > 120;
+    const isKeyboardOpen = isEditableFocused && keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
 
     root.style.setProperty('--viewport-height', `${h}px`);
     root.style.setProperty('--viewport-offset', `${offset}px`);


### PR DESCRIPTION
  ## ✨ 요약
  ```ts
  - 채팅방 입력 영역의 기본 하단 패딩을 22px에서 12px로 조정했습니다.
  - VisualViewport와 입력 포커스 상태를 함께 사용해 가상 키보드 활성화 여부를 판단하도록 변경했습니다.
  - 키보드가 열려 있을 때는 채팅 입력 영역의 safe area 하단 패딩을 제거해, 키보드와 입력창 사이 간격이 과하게 벌어지지 않도록 수정했습니다.
  - 키보드가 닫히면 기존 safe area 패딩이 다시 적용되도록 처리했습니다.
``` 

  <br><br>

  ## 😎 해결한 이슈

  - close #222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **스타일 개선**
  * 모바일에서 채팅 입력 필드의 하단 패딩과 위치 처리를 더 정확하게 조정합니다.
  * 화면 하단 안전 영역 값을 새로 관리해 키보드 노출 시 입력 필드 간격을 안정적으로 유지합니다.
* **버그 수정**
  * 입력 요소 포커스 상태와 뷰포트 변화를 더 정확히 감지해 키보드 높이 판단 오류를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->