### PR TITLE
[fix] 키보드 활성화 시 viewport offset으로 채팅 레이아웃이 흔들리는 문제 수정

### DIFF
--- a/src/utils/ts/viewport.ts
+++ b/src/utils/ts/viewport.ts
@@ -29,7 +29,7 @@ export function installViewportVars() {
     const isKeyboardOpen = isEditableFocused && keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
 
     root.style.setProperty('--viewport-height', `${h}px`);
-    root.style.setProperty('--viewport-offset', `${offset}px`);
+    root.style.setProperty('--viewport-offset', isEditableFocused ? '0px' : `${offset}px`);
     root.style.setProperty('--effective-bottom-safe-area', isKeyboardOpen ? '0px' : 'var(--sab)');
   };
 


### PR DESCRIPTION
## ✨ 요약

```ts
- 입력 포커스 중에는 루트 레이아웃의 viewport offset을 0으로 고정하도록 수정했습니다.
- visualViewport.offsetTop 변화가 헤더를 포함한 전체 채팅 레이아웃에 전달되지 않도록 조정했습니다.
- 이를 통해 키보드 활성화 초기에 화면 전체가 위아래로 흔들리는 현상을 줄이도록 수정했습니다.
- pnpm lint 검증을 완료했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 편집창이 활성화된 경우 뷰포트 오프셋을 자동으로 조정했습니다.
  * 편집창이 비활성화된 경우 계산된 오프셋 값을 정확히 유지하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->