### PR TITLE
[fix] 키보드 활성화 후 문서 루트 스크롤로 빈 공간이 남는 문제 수정

### DIFF
--- a/src/utils/hooks/useViewportHeightLock.ts
+++ b/src/utils/hooks/useViewportHeightLock.ts
@@ -6,13 +6,16 @@ function useViewportHeightLock() {
     const body = document.body;
     const prevBodyOverflow = body.style.overflow;
     const prevBodyHeight = body.style.height;
+    const prevRootOverflow = root.style.overflow;
     const prevRootHeight = root.style.height;
 
+    root.style.overflow = 'hidden';
     body.style.overflow = 'hidden';
     body.style.height = 'var(--viewport-height)';
     root.style.height = 'var(--viewport-height)';
 
     return () => {
+      root.style.overflow = prevRootOverflow;
       body.style.overflow = prevBodyOverflow;
       body.style.height = prevBodyHeight;
       root.style.height = prevRootHeight;


### PR DESCRIPTION
## ✨ 요약

```ts
- 채팅 화면에서 viewport 높이를 잠그는 동안 html(documentElement)도 함께 overflow hidden 처리하도록 수정했습니다.
- 가상 키보드 활성화 시 문서 루트가 스크롤되며 헤더가 사라지고 빈 공간이 남는 현상을 줄이도록 조정했습니다.
- body뿐 아니라 루트 문서 스크롤도 함께 잠가, 키보드 활성화 중 전체 페이지가 패닝되지 않도록 수정했습니다.
- pnpm lint 검증을 완료했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #231