### PR TITLE
[fix] 키보드 활성화 시 채팅 화면에서 문서 스크롤이 발생하는 문제 수정

### DIFF
--- a/src/pages/Chat/ChatRoom.tsx
+++ b/src/pages/Chat/ChatRoom.tsx
@@ -84,8 +84,6 @@ function ChatRoom() {
     useChat(Number(chatRoomId));
   const [value, setValue] = useState('');
 
-  useViewportHeightLock();
-
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const baseTextareaHeightRef = useRef(0);
   const { scrollContainerRef, topRef, scrollToBottom } = useChatRoomScroll({
@@ -96,6 +94,8 @@ function ChatRoom() {
     hasNextPage,
     isFetchingNextPage,
   });
+
+  useViewportHeightLock(scrollContainerRef);
 
   const currentRoom = chatRoomList.rooms.find((room) => room.roomId === Number(chatRoomId));
 

--- a/src/utils/hooks/useViewportHeightLock.ts
+++ b/src/utils/hooks/useViewportHeightLock.ts
@@ -1,9 +1,9 @@
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, type RefObject } from 'react';
 import { isTextInputElement } from '@/utils/ts/dom';
 
 const SCROLL_RESET_TIMEOUT_MS = 180;
 
-function useViewportHeightLock() {
+function useViewportHeightLock(scrollContainerRef?: RefObject<HTMLElement | null>) {
   useLayoutEffect(() => {
     const root = document.documentElement;
     const body = document.body;
@@ -64,7 +64,43 @@ function useViewportHeightLock() {
       }
     };
 
+    let lastTouchClientY = 0;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      if (event.touches.length !== 1) return;
+
+      lastTouchClientY = event.touches[0].clientY;
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (event.touches.length !== 1) return;
+
+      const scrollContainer = scrollContainerRef?.current;
+      const target = event.target;
+
+      if (!scrollContainer) return;
+
+      if (!(target instanceof Node) || !scrollContainer.contains(target)) {
+        event.preventDefault();
+        return;
+      }
+
+      const currentTouchClientY = event.touches[0].clientY;
+      const deltaY = currentTouchClientY - lastTouchClientY;
+      const canScroll = scrollContainer.scrollHeight > scrollContainer.clientHeight;
+      const isAtTop = scrollContainer.scrollTop <= 0;
+      const isAtBottom = scrollContainer.scrollTop + scrollContainer.clientHeight >= scrollContainer.scrollHeight - 1;
+
+      lastTouchClientY = currentTouchClientY;
+
+      if (!canScroll || (deltaY > 0 && isAtTop) || (deltaY < 0 && isAtBottom)) {
+        event.preventDefault();
+      }
+    };
+
     const handleWindowScroll = () => {
+      if (!isEditableFocused) return;
+
       const currentScrollTop = Math.max(
         scrollingElement?.scrollTop ?? 0,
         root.scrollTop,
@@ -88,6 +124,8 @@ function useViewportHeightLock() {
     window.addEventListener('focusin', handleFocusIn);
     window.addEventListener('focusout', handleFocusOut);
     window.addEventListener('scroll', handleWindowScroll, { passive: true });
+    document.addEventListener('touchstart', handleTouchStart, { passive: true });
+    document.addEventListener('touchmove', handleTouchMove, { passive: false });
 
     window.visualViewport?.addEventListener('resize', handleViewportChange);
     window.visualViewport?.addEventListener('scroll', handleViewportChange);
@@ -100,6 +138,8 @@ function useViewportHeightLock() {
       window.removeEventListener('focusin', handleFocusIn);
       window.removeEventListener('focusout', handleFocusOut);
       window.removeEventListener('scroll', handleWindowScroll);
+      document.removeEventListener('touchstart', handleTouchStart);
+      document.removeEventListener('touchmove', handleTouchMove);
 
       window.visualViewport?.removeEventListener('resize', handleViewportChange);
       window.visualViewport?.removeEventListener('scroll', handleViewportChange);
@@ -109,7 +149,7 @@ function useViewportHeightLock() {
       body.style.height = prevBodyHeight;
       root.style.height = prevRootHeight;
     };
-  }, []);
+  }, [scrollContainerRef]);
 }
 
 export default useViewportHeightLock;

--- a/src/utils/hooks/useViewportHeightLock.ts
+++ b/src/utils/hooks/useViewportHeightLock.ts
@@ -74,11 +74,16 @@ function useViewportHeightLock(scrollContainerRef?: RefObject<HTMLElement | null
 
     const handleTouchMove = (event: TouchEvent) => {
       if (event.touches.length !== 1) return;
+      if (!isEditableFocused) return;
 
       const scrollContainer = scrollContainerRef?.current;
       const target = event.target;
+      const targetElement =
+        target instanceof HTMLElement ? target : target instanceof Node ? target.parentElement : null;
+      const editableElement = targetElement?.closest('input, textarea, [contenteditable]');
 
       if (!scrollContainer) return;
+      if (editableElement instanceof HTMLElement && isTextInputElement(editableElement)) return;
 
       if (!(target instanceof Node) || !scrollContainer.contains(target)) {
         event.preventDefault();


### PR DESCRIPTION
## ✨ 요약

```ts
- 채팅방에서 viewport 높이 잠금 훅이 메시지 리스트 스크롤 컨테이너를 직접 받도록 변경했습니다.
- 문서 전체에 대한 touchmove는 차단하고, 채팅 메시지 리스트 안에서 실제로 스크롤 가능한 경우에만 내부 스크롤이 동작하도록 조정했습니다.
- 입력 포커스 중에는 문서 scroll reset을 유지하되, 사용자 제스처로 문서 스크롤이 생겼다가 즉시 되돌아오는 느낌을 줄이도록 구조를 보강했습니다.
- pnpm lint 검증을 완료했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅창 스크롤 컨테이너의 뷰포트 높이 잠금 기능을 개선했습니다.
  * 터치 이벤트 처리를 추가하여 모바일에서의 스크롤 반응성을 향상시켰습니다.
  * 컨테이너 경계에서의 스크롤 동작을 보다 정확하게 제어하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->