### PR TITLE
[fix] 키보드 활성화 시 채팅방이 마지막 메시지 위치를 유지하지 못하는 문제 수정

### DIFF
--- a/src/pages/Chat/hooks/useChatRoomScroll.ts
+++ b/src/pages/Chat/hooks/useChatRoomScroll.ts
@@ -29,6 +29,7 @@ const useChatRoomScroll = ({
   const shouldRestoreScrollRef = useRef(false);
   const previousScrollTopRef = useRef(0);
   const previousScrollHeightRef = useRef(0);
+  const previousClientHeightRef = useRef(0);
   const isNearBottomRef = useRef(true);
 
   const scrollToBottom = useCallback(() => {
@@ -59,6 +60,7 @@ const useChatRoomScroll = ({
     shouldRestoreScrollRef.current = false;
     previousScrollTopRef.current = 0;
     previousScrollHeightRef.current = 0;
+    previousClientHeightRef.current = 0;
     isNearBottomRef.current = true;
   }, [chatRoomId]);
 
@@ -100,6 +102,31 @@ const useChatRoomScroll = ({
       scrollToBottom();
     }
   }, [chatMessagesLength, latestMessageId, scrollToBottom]);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    previousClientHeightRef.current = container.clientHeight;
+
+    const resizeObserver = new ResizeObserver(() => {
+      const nextClientHeight = container.clientHeight;
+
+      if (nextClientHeight === previousClientHeightRef.current) return;
+
+      previousClientHeightRef.current = nextClientHeight;
+
+      if (chatMessagesLength === 0 || !isNearBottomRef.current) return;
+
+      requestAnimationFrame(scrollToBottom);
+    });
+
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [chatMessagesLength, scrollToBottom]);
 
   return {
     scrollContainerRef,

--- a/src/pages/Chat/hooks/useChatRoomScroll.ts
+++ b/src/pages/Chat/hooks/useChatRoomScroll.ts
@@ -25,6 +25,7 @@ const useChatRoomScroll = ({
   isFetchingNextPage,
 }: UseChatRoomScrollParams) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const chatMessagesLengthRef = useRef(chatMessagesLength);
   const isInitialScrollDoneRef = useRef(false);
   const shouldRestoreScrollRef = useRef(false);
   const previousScrollTopRef = useRef(0);
@@ -54,6 +55,10 @@ const useChatRoomScroll = ({
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const topRef = useInfiniteScroll(handleFetchNextPage, hasNextPage, isFetchingNextPage, { threshold: 0.1 });
+
+  useEffect(() => {
+    chatMessagesLengthRef.current = chatMessagesLength;
+  }, [chatMessagesLength]);
 
   useEffect(() => {
     isInitialScrollDoneRef.current = false;
@@ -109,24 +114,27 @@ const useChatRoomScroll = ({
 
     previousClientHeightRef.current = container.clientHeight;
 
-    const resizeObserver = new ResizeObserver(() => {
-      const nextClientHeight = container.clientHeight;
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => {
+            const nextClientHeight = container.clientHeight;
 
-      if (nextClientHeight === previousClientHeightRef.current) return;
+            if (nextClientHeight === previousClientHeightRef.current) return;
 
-      previousClientHeightRef.current = nextClientHeight;
+            previousClientHeightRef.current = nextClientHeight;
 
-      if (chatMessagesLength === 0 || !isNearBottomRef.current) return;
+            if (chatMessagesLengthRef.current === 0 || !isNearBottomRef.current) return;
 
-      requestAnimationFrame(scrollToBottom);
-    });
+            requestAnimationFrame(scrollToBottom);
+          })
+        : undefined;
 
-    resizeObserver.observe(container);
+    resizeObserver?.observe(container);
 
     return () => {
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
     };
-  }, [chatMessagesLength, scrollToBottom]);
+  }, [chatRoomId, scrollToBottom]);
 
   return {
     scrollContainerRef,


### PR DESCRIPTION
## ✨ 요약

```ts
- 채팅 스크롤 훅에서 메시지 리스트 컨테이너의 clientHeight 변화를 추적하도록 보강했습니다.
- 사용자가 원래 하단 근처에 있는 상태라면, 키보드 활성화로 컨테이너 높이가 바뀌어도 ResizeObserver를 통해 다시 하단으로 정렬되도록 수정했습니다.
- 메시지 추가뿐 아니라 viewport 높이 변화에도 마지막 메시지가 계속 보이도록 동작을 맞췄습니다.
- pnpm lint 검증을 완료했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #237