### PR TITLE
[fix] mypage 연계 약관 페이지 뒤로가기 수정

### DIFF
--- a/src/pages/Auth/SignUp/TermStep.tsx
+++ b/src/pages/Auth/SignUp/TermStep.tsx
@@ -53,6 +53,7 @@ function TermStep() {
             onChange={setTerms}
             label="[필수] 서비스 이용약관"
             route="/legal/terms"
+            state={{ backPath: '/signup' }}
             CheckIcon={CheckIcon}
             RightIcon={RightArrowIcon}
           />
@@ -62,6 +63,7 @@ function TermStep() {
             onChange={setPrivacy}
             label="[필수] 개인정보 처리방침"
             route="/legal/privacy"
+            state={{ backPath: '/signup' }}
             CheckIcon={CheckIcon}
             RightIcon={RightArrowIcon}
           />
@@ -71,6 +73,7 @@ function TermStep() {
             onChange={setMarketing}
             label="[선택] 마케팅 정보 수신"
             route="/legal/marketing"
+            state={{ backPath: '/signup' }}
             CheckIcon={CheckIcon}
             RightIcon={RightArrowIcon}
           />

--- a/src/pages/Auth/SignUp/components/AgreementArrow.tsx
+++ b/src/pages/Auth/SignUp/components/AgreementArrow.tsx
@@ -1,16 +1,21 @@
 import type { ComponentType } from 'react';
 import { Link } from 'react-router-dom';
 
+interface AgreementLinkState {
+  backPath?: string;
+}
+
 type AgreementRowProps = {
   checked: boolean;
   onChange: (next: boolean) => void;
   label: string;
   route: string;
+  state?: AgreementLinkState;
   RightIcon?: ComponentType<React.SVGAttributes<SVGElement>>;
   CheckIcon: ComponentType<React.SVGAttributes<SVGElement>>;
 };
 
-function AgreementRow({ checked, onChange, label, route, RightIcon, CheckIcon }: AgreementRowProps) {
+function AgreementRow({ checked, onChange, label, route, state, RightIcon, CheckIcon }: AgreementRowProps) {
   return (
     <div className="flex justify-between">
       <label className="flex cursor-pointer items-center gap-3">
@@ -25,7 +30,7 @@ function AgreementRow({ checked, onChange, label, route, RightIcon, CheckIcon }:
       </label>
 
       {RightIcon ? (
-        <Link to={route}>
+        <Link to={route} state={state}>
           <RightIcon className="text-indigo-100" />
         </Link>
       ) : null}

--- a/src/pages/User/MyPage/index.tsx
+++ b/src/pages/User/MyPage/index.tsx
@@ -35,7 +35,12 @@ function MyPage() {
         {menuItems
           .filter(({ to }) => to !== 'manager' || myInfo.isClubManager || myInfo.role === 'ADMIN')
           .map(({ to, icon: Icon, label }) => (
-            <Link key={to} to={to} className="bg-indigo-0 active:bg-indigo-5 rounded-sm transition-colors">
+            <Link
+              key={to}
+              to={to}
+              state={to.startsWith('/legal/') ? { backPath: '/mypage' } : undefined}
+              className="bg-indigo-0 active:bg-indigo-5 rounded-sm transition-colors"
+            >
               <div className="flex items-center justify-between px-3 py-2">
                 <div className="flex items-center gap-4">
                   <Icon />

--- a/src/utils/hooks/useSmartBack.ts
+++ b/src/utils/hooks/useSmartBack.ts
@@ -1,13 +1,29 @@
 import { useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
+interface SmartBackState {
+  backPath?: string;
+  backReplace?: boolean;
+  backState?: { from?: string };
+  from?: string;
+}
+
 export function useSmartBack() {
   const navigate = useNavigate();
   const location = useLocation();
   const { pathname } = location;
-  const fromClubList = location.state?.from === 'clubList';
+  const navigationState = location.state as SmartBackState | null;
+  const fromClubList = navigationState?.from === 'clubList';
 
   return useCallback(() => {
+    if (navigationState?.backPath) {
+      navigate(navigationState.backPath, {
+        replace: navigationState.backReplace ?? true,
+        state: navigationState.backState,
+      });
+      return;
+    }
+
     let targetPath = '/home';
     let state: { from?: string } | undefined;
     let replace = true;
@@ -77,5 +93,5 @@ export function useSmartBack() {
     }
 
     navigate(targetPath, { replace, state });
-  }, [navigate, pathname, fromClubList]);
+  }, [navigate, pathname, fromClubList, navigationState]);
 }


### PR DESCRIPTION
## ✨ 요약

```ts
- legal 페이지 뒤로가기에서 location.state 기반 backPath를 우선 사용하도록 useSmartBack을 확장했습니다.
- mypage에서 진입하는 오픈소스 라이선스/코넥트 약관 확인/개인정보 처리방침 페이지에 backPath=/mypage를 전달하도록 수정했습니다.
- signup 약관 동의 단계에서 진입하는 legal 페이지에는 backPath=/signup을 전달해 기존 흐름이 유지되도록 했습니다.
- 검증: pnpm lint, pnpm build
```

<br><br>

## 😎 해결한 이슈

- close #239

<br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 약관, 개인정보보호정책, 마케팅 동의 페이지에서 뒤로가기 기능이 개선되어 사용자가 이전 페이지로 올바르게 돌아갈 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->