### PR TITLE
apiClient 코드 중복 제거 및 네이티브 브릿지 인증 동기화 중앙화

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -143,10 +143,14 @@ function buildFetchOptions<P extends object>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { headers, body, method, params, requiresAuth, ...restOptions } = options;
 
-  const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
+  const isPlainObjectOrArray =
+    body !== undefined &&
+    body !== null &&
+    typeof body === 'object' &&
+    (Array.isArray(body) || body.constructor === Object);
 
   const h: Record<string, string> = {
-    ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
+    ...(isPlainObjectOrArray ? { 'Content-Type': 'application/json' } : {}),
     ...headers,
   };
 
@@ -166,10 +170,7 @@ function buildFetchOptions<P extends object>(
   };
 
   if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
-    fetchOpts.body =
-      typeof body === 'object' && !(body instanceof Blob) && !(body instanceof FormData)
-        ? JSON.stringify(body)
-        : (body as BodyInit);
+    fetchOpts.body = isPlainObjectOrArray ? JSON.stringify(body) : (body as BodyInit);
   }
 
   return fetchOpts;

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -2,6 +2,7 @@ import { refreshAccessToken } from '@/apis/auth';
 import type { ApiError, ApiErrorResponse } from '@/interface/error';
 import { useAuthStore } from '@/stores/authStore';
 import { isServerErrorStatus, redirectToServerErrorPage } from '@/utils/ts/errorRedirect';
+import { postNativeMessage } from '@/utils/ts/nativeBridge';
 
 const BASE_URL = import.meta.env.VITE_API_PATH;
 
@@ -18,8 +19,6 @@ interface FetchOptions<P extends object = Record<string, QueryParamValue>> exten
   params?: P;
   requiresAuth?: boolean;
 }
-
-let refreshPromise: Promise<string> | null = null;
 
 export const apiClient = {
   get: <T = unknown, P extends object = Record<string, QueryParamValue>>(
@@ -128,22 +127,60 @@ function buildQuery(params: Record<string, QueryParamValue>) {
   return usp.toString();
 }
 
-async function sendRequest<T = unknown, P extends object = Record<string, QueryParamValue>>(
-  endPoint: string,
-  options: FetchOptions<P> = {},
-  timeout: number = 10000
-): Promise<T> {
-  const { headers, body, method, params, requiresAuth, ...restOptions } = options;
-
-  if (!method) {
-    throw new Error('HTTP method가 설정되지 않았습니다.');
-  }
-
+function buildUrl(endPoint: string, params?: Record<string, QueryParamValue>): string {
   let url = joinUrl(BASE_URL, endPoint);
   if (params && Object.keys(params).length > 0) {
-    const query = buildQuery(params as Record<string, QueryParamValue>);
+    const query = buildQuery(params);
     if (query) url += `?${query}`;
   }
+  return url;
+}
+
+function buildFetchOptions<P extends object>(
+  options: FetchOptions<P> & { method: string },
+  abortSignal: AbortSignal
+): RequestInit {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { headers, body, method, params, requiresAuth, ...restOptions } = options;
+
+  const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
+
+  const h: Record<string, string> = {
+    ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
+    ...headers,
+  };
+
+  if (requiresAuth) {
+    const accessToken = useAuthStore.getState().getAccessToken();
+    if (accessToken) {
+      h['Authorization'] = `Bearer ${accessToken}`;
+    }
+  }
+
+  const fetchOpts: RequestInit = {
+    headers: h,
+    method,
+    signal: abortSignal,
+    credentials: 'include',
+    ...restOptions,
+  };
+
+  if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
+    fetchOpts.body =
+      typeof body === 'object' && !(body instanceof Blob) && !(body instanceof FormData)
+        ? JSON.stringify(body)
+        : (body as BodyInit);
+  }
+
+  return fetchOpts;
+}
+
+async function executeFetch<P extends object>(
+  endPoint: string,
+  options: FetchOptions<P> & { method: string },
+  timeout: number
+): Promise<{ response: Response; timeoutId: ReturnType<typeof setTimeout> }> {
+  const url = buildUrl(endPoint, options.params as Record<string, QueryParamValue> | undefined);
 
   const abortController = new AbortController();
   let didTimeout = false;
@@ -152,44 +189,36 @@ async function sendRequest<T = unknown, P extends object = Record<string, QueryP
     abortController.abort();
   }, timeout);
 
-  const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
+  try {
+    const fetchOpts = buildFetchOptions(options, abortController.signal);
+    const response = await fetch(url, fetchOpts);
+    return { response, timeoutId };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    rethrowFetchError(error, url, didTimeout);
+  }
+}
 
-  const buildHeaders = (): Record<string, string> => {
-    const h: Record<string, string> = {
-      ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
-      ...headers,
-    };
+async function sendRequest<T = unknown, P extends object = Record<string, QueryParamValue>>(
+  endPoint: string,
+  options: FetchOptions<P> = {},
+  timeout: number = 10000,
+  allowRetry: boolean = true
+): Promise<T> {
+  const { method } = options;
 
-    if (requiresAuth) {
-      const accessToken = useAuthStore.getState().getAccessToken();
-      if (accessToken) {
-        h['Authorization'] = `Bearer ${accessToken}`;
-      }
-    }
+  if (!method) {
+    throw new Error('HTTP method가 설정되지 않았습니다.');
+  }
 
-    return h;
-  };
+  const { response, timeoutId } = await executeFetch<P>(
+    endPoint,
+    options as FetchOptions<P> & { method: string },
+    timeout
+  );
 
   try {
-    const fetchOptions: RequestInit = {
-      headers: buildHeaders(),
-      method,
-      signal: abortController.signal,
-      credentials: 'include',
-      ...restOptions,
-    };
-
-    if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
-      fetchOptions.body =
-        typeof body === 'object' && !(body instanceof Blob) && !(body instanceof FormData)
-          ? JSON.stringify(body)
-          : (body as BodyInit);
-    }
-
-    const response = await fetch(url, fetchOptions);
-
-    if (response.status === 401 && requiresAuth) {
-      clearTimeout(timeoutId);
+    if (response.status === 401 && options.requiresAuth && allowRetry) {
       return await handleUnauthorized<T, P>(endPoint, options, timeout);
     }
 
@@ -198,8 +227,6 @@ async function sendRequest<T = unknown, P extends object = Record<string, QueryP
     }
 
     return parseResponse<T>(response);
-  } catch (error) {
-    rethrowFetchError(error, url, didTimeout);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -213,98 +240,16 @@ async function handleUnauthorized<T = unknown, P extends object = Record<string,
   let newAccessToken: string;
 
   try {
-    if (!refreshPromise) {
-      refreshPromise = refreshAccessToken();
-    }
-    newAccessToken = await refreshPromise;
+    newAccessToken = await refreshAccessToken();
   } catch {
-    // refresh 실패 → 인증 만료, 로그아웃 처리
     useAuthStore.getState().clearAuth();
     throw new Error('인증이 만료되었습니다.');
-  } finally {
-    refreshPromise = null;
   }
 
   useAuthStore.getState().setAccessToken(newAccessToken);
+  postNativeMessage({ type: 'TOKEN_REFRESH', accessToken: newAccessToken });
 
-  try {
-    if (window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'TOKEN_REFRESH', accessToken: newAccessToken }));
-    }
-  } catch {
-    // 브릿지 전달 실패가 인증 흐름을 중단시키지 않도록 무시
-  }
-
-  // retry 실패는 그대로 throw (로그아웃 처리 안 함)
-  return await sendRequestWithoutRetry<T, P>(endPoint, options, timeout);
-}
-
-async function sendRequestWithoutRetry<T = unknown, P extends object = Record<string, QueryParamValue>>(
-  endPoint: string,
-  options: FetchOptions<P> = {},
-  timeout: number = 10000
-): Promise<T> {
-  const { headers, body, method, params, requiresAuth, ...restOptions } = options;
-
-  if (!method) {
-    throw new Error('HTTP method가 설정되지 않았습니다.');
-  }
-
-  let url = joinUrl(BASE_URL, endPoint);
-  if (params && Object.keys(params).length > 0) {
-    const query = buildQuery(params as Record<string, QueryParamValue>);
-    if (query) url += `?${query}`;
-  }
-
-  const abortController = new AbortController();
-  let didTimeout = false;
-  const timeoutId = setTimeout(() => {
-    didTimeout = true;
-    abortController.abort();
-  }, timeout);
-
-  const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
-
-  try {
-    const h: Record<string, string> = {
-      ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
-      ...headers,
-    };
-
-    if (requiresAuth) {
-      const accessToken = useAuthStore.getState().getAccessToken();
-      if (accessToken) {
-        h['Authorization'] = `Bearer ${accessToken}`;
-      }
-    }
-
-    const fetchOptions: RequestInit = {
-      headers: h,
-      method,
-      signal: abortController.signal,
-      credentials: 'include',
-      ...restOptions,
-    };
-
-    if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
-      fetchOptions.body =
-        typeof body === 'object' && !(body instanceof Blob) && !(body instanceof FormData)
-          ? JSON.stringify(body)
-          : (body as BodyInit);
-    }
-
-    const response = await fetch(url, fetchOptions);
-
-    if (!response.ok) {
-      return await throwApiError(response);
-    }
-
-    return parseResponse<T>(response);
-  } catch (error) {
-    rethrowFetchError(error, url, didTimeout);
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  return await sendRequest<T, P>(endPoint, options, timeout, false);
 }
 
 async function parseErrorResponse(response: Response): Promise<ApiErrorResponse | null> {
@@ -320,16 +265,28 @@ async function parseErrorResponse(response: Response): Promise<ApiErrorResponse 
 }
 
 async function parseResponse<T = unknown>(response: Response): Promise<T> {
+  if (response.status === 204 || response.headers.get('Content-Length') === '0') {
+    return null as unknown as T;
+  }
+
   const contentType = response.headers.get('Content-Type') || '';
+
   if (contentType.includes('application/json')) {
     try {
       return await response.json();
     } catch {
-      return {} as T;
+      const error = new Error('응답 JSON 파싱에 실패했습니다.') as ApiError;
+      error.name = 'ParseError';
+      error.status = response.status;
+      error.statusText = response.statusText;
+      error.url = response.url;
+      throw error;
     }
-  } else if (contentType.includes('text')) {
-    return (await response.text()) as unknown as T;
-  } else {
-    return null as unknown as T;
   }
+
+  if (contentType.includes('text')) {
+    return (await response.text()) as unknown as T;
+  }
+
+  return null as unknown as T;
 }

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -218,6 +218,8 @@ async function sendRequest<T = unknown, P extends object = Record<string, QueryP
     timeout
   );
 
+  const url = response.url;
+
   try {
     if (response.status === 401 && options.requiresAuth && allowRetry) {
       return await handleUnauthorized<T, P>(endPoint, options, timeout);
@@ -227,7 +229,12 @@ async function sendRequest<T = unknown, P extends object = Record<string, QueryP
       return await throwApiError(response);
     }
 
-    return parseResponse<T>(response);
+    return await parseResponse<T>(response);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      rethrowFetchError(error, url, true);
+    }
+    throw error;
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/components/notification/hooks/useInboxNotificationStream.ts
+++ b/src/components/notification/hooks/useInboxNotificationStream.ts
@@ -4,6 +4,7 @@ import type { InboxNotification } from '@/apis/notification/entity';
 import { useAuthStore } from '@/stores/authStore';
 import { getAccessTokenExpirationTime } from '@/utils/ts/accessToken';
 import { isServerErrorStatus, redirectToServerErrorPage } from '@/utils/ts/errorRedirect';
+import { postNativeMessage } from '@/utils/ts/nativeBridge';
 import { NORMALIZED_API_BASE_URL } from '@/utils/ts/oauth';
 
 const ACCESS_TOKEN_REFRESH_BUFFER_MS = 60_000;
@@ -60,16 +61,6 @@ function parseSseEvent(chunk: string): { event: string | null; data: string | nu
   };
 }
 
-function syncAccessTokenToNative(accessToken: string) {
-  try {
-    if (window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'TOKEN_REFRESH', accessToken }));
-    }
-  } catch {
-    // 브릿지 전달 실패가 인증 흐름을 중단시키지 않도록 무시
-  }
-}
-
 async function openInboxNotificationStream(
   signal: AbortSignal,
   onConnected: () => void,
@@ -106,7 +97,7 @@ async function openInboxNotificationStream(
       try {
         const nextAccessToken = await refreshAccessToken();
         useAuthStore.getState().setAccessToken(nextAccessToken);
-        syncAccessTokenToNative(nextAccessToken);
+        postNativeMessage({ type: 'TOKEN_REFRESH', accessToken: nextAccessToken });
       } catch {
         useAuthStore.getState().clearAuth();
         throw new Error('인증이 만료되었습니다.');
@@ -224,7 +215,7 @@ export function useInboxNotificationStream(
         }
 
         useAuthStore.getState().setAccessToken(nextAccessToken);
-        syncAccessTokenToNative(nextAccessToken);
+        postNativeMessage({ type: 'TOKEN_REFRESH', accessToken: nextAccessToken });
       } catch {
         if (isCancelled || useAuthStore.getState().getAccessToken() !== accessToken) {
           return;

--- a/src/pages/User/MyPage/hooks/useLogout.ts
+++ b/src/pages/User/MyPage/hooks/useLogout.ts
@@ -10,13 +10,6 @@ export const useLogoutMutation = () => {
   return useMutation({
     ...authMutations.logout(),
     onSuccess: () => {
-      try {
-        if (window.ReactNativeWebView) {
-          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'LOGOUT' }));
-        }
-      } catch {
-        // 브릿지 전달 실패가 로그아웃 흐름을 중단시키지 않도록 무시
-      }
       clearAuth();
       navigate('/');
     },

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { getMyInfo, refreshAccessToken } from '@/apis/auth';
 import type { MyInfoResponse } from '@/apis/auth/entity';
 import { isAccessTokenExpired } from '@/utils/ts/accessToken';
+import { postNativeMessage } from '@/utils/ts/nativeBridge';
 
 let initializePromise: Promise<void> | null = null;
 let hydrateUserPromise: Promise<void> | null = null;
@@ -19,15 +20,7 @@ const hydrateUser = async (nextAccessToken: string) => {
 
       useAuthStore.setState({ user: nextUser });
 
-      try {
-        if (window.ReactNativeWebView) {
-          window.ReactNativeWebView.postMessage(
-            JSON.stringify({ type: 'LOGIN_COMPLETE', accessToken: nextAccessToken })
-          );
-        }
-      } catch {
-        // 브릿지 전달 실패가 인증 성공 상태를 롤백시키지 않도록 무시
-      }
+      postNativeMessage({ type: 'LOGIN_COMPLETE', accessToken: nextAccessToken });
     } catch {
       if (useAuthStore.getState().accessToken !== nextAccessToken) return;
 
@@ -95,7 +88,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         set({ accessToken: nextAccessToken, authStatus: 'authenticated' });
         void hydrateUser(nextAccessToken);
       } catch {
-        set({ user: null, accessToken: null, authStatus: 'anonymous' });
+        get().clearAuth();
       } finally {
         initializePromise = null;
       }
@@ -122,5 +115,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     initializePromise = null;
     hydrateUserPromise = null;
     set({ user: null, accessToken: null, authStatus: 'anonymous' });
+    postNativeMessage({ type: 'LOGOUT' });
   },
 }));

--- a/src/utils/ts/nativeBridge.ts
+++ b/src/utils/ts/nativeBridge.ts
@@ -1,0 +1,12 @@
+type BridgeMessage =
+  | { type: 'TOKEN_REFRESH'; accessToken: string }
+  | { type: 'LOGIN_COMPLETE'; accessToken: string }
+  | { type: 'LOGOUT' };
+
+export function postNativeMessage(message: BridgeMessage): void {
+  try {
+    window.ReactNativeWebView?.postMessage(JSON.stringify(message));
+  } catch {
+    // 브릿지 전달 실패가 앱 흐름을 중단시키지 않도록 무시
+  }
+}


### PR DESCRIPTION
## ✨ 요약

- `sendRequest` / `sendRequestWithoutRetry` 중복 함수를 `allowRetry` 파라미터로 통합하고, 공통 로직을 `buildUrl`, `buildFetchOptions`, `executeFetch`로 분리
- `client.ts`의 모듈 스코프 `refreshPromise` 제거 (`auth/index.ts`의 dedup에 위임)
- `postNativeMessage` 유틸을 추출하여 모든 네이티브 브릿지 호출(`TOKEN_REFRESH`, `LOGIN_COMPLETE`, `LOGOUT`)을 타입 안전하게 중앙화
- `clearAuth()` 내부에서 LOGOUT 브릿지 전송 → 회원탈퇴, 알림 스트림 등 모든 인증 해제 경로에서 네이티브 동기화 보장
- `initialize()` refresh 실패 경로도 `clearAuth()` 경유하도록 통일
- `parseResponse` JSON 파싱 실패 시 `ApiError` 형태로 래핑 (`status`, `statusText`, `url` 포함), 204 No Content 명시 처리

## 😎 해결한 이슈

close #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 응답 파싱 실패 시 오류 처리 개선

* **리팩토링**
  * 인증 토큰 갱신 메커니즘 최적화로 성능 향상
  * API 요청 생성 및 실행 프로세스 개선
  * 인증 요청 재시도 로직 정교화
  * 네이티브 애플리케이션 간 메시지 통신 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->