### PR TITLE
[feat] 사용자 채팅방 이름 변경 및 채팅방 나가기 기능 추가

### DIFF
--- a/src/apis/chat/index.ts
+++ b/src/apis/chat/index.ts
@@ -49,3 +49,18 @@ export const postAdminChatRoom = async () => {
   });
   return response;
 };
+
+export const patchChatRoomName = async (chatRoomId: number, name: string) => {
+  const response = await apiClient.patch(`chats/rooms/${chatRoomId}/name`, {
+    body: { roomName: name },
+    requiresAuth: true,
+  });
+  return response;
+};
+
+export const deleteChatRoom = async (chatRoomId: number) => {
+  const response = await apiClient.delete(`chats/rooms/${chatRoomId}`, {
+    requiresAuth: true,
+  });
+  return response;
+};

--- a/src/apis/chat/mutations.ts
+++ b/src/apis/chat/mutations.ts
@@ -1,5 +1,12 @@
 import { mutationOptions } from '@tanstack/react-query';
-import { patchChatRoomName, postAdminChatRoom, postChatMessage, postChatMute, postChatRooms } from '@/apis/chat';
+import {
+  patchChatRoomName,
+  postAdminChatRoom,
+  postChatMessage,
+  postChatMute,
+  postChatRooms,
+  deleteChatRoom,
+} from '@/apis/chat';
 
 export const chatMutationKeys = {
   createRoom: () => ['chat', 'createRoom'] as const,
@@ -7,6 +14,7 @@ export const chatMutationKeys = {
   sendMessage: () => ['chat', 'sendMessage'] as const,
   toggleMute: (chatRoomId?: number) => ['chat', 'toggleMute', chatRoomId ?? 'unknown'] as const,
   updateRoomName: () => ['chat', 'updateRoomName'] as const,
+  deleteRoom: () => ['chat', 'deleteRoom'] as const,
 };
 
 export const chatMutations = {
@@ -40,5 +48,10 @@ export const chatMutations = {
     mutationOptions({
       mutationKey: chatMutationKeys.updateRoomName(),
       mutationFn: ({ chatRoomId, name }: { chatRoomId: number; name: string }) => patchChatRoomName(chatRoomId, name),
+    }),
+  deleteRoom: () =>
+    mutationOptions({
+      mutationKey: chatMutationKeys.deleteRoom(),
+      mutationFn: (chatRoomId: number) => deleteChatRoom(chatRoomId),
     }),
 };

--- a/src/apis/chat/mutations.ts
+++ b/src/apis/chat/mutations.ts
@@ -33,10 +33,10 @@ export const chatMutations = {
       mutationKey: chatMutationKeys.sendMessage(),
       mutationFn: postChatMessage,
     }),
-  toggleMute: (chatRoomId?: number) =>
+  toggleMute: () =>
     mutationOptions({
-      mutationKey: chatMutationKeys.toggleMute(chatRoomId),
-      mutationFn: async () => {
+      mutationKey: chatMutationKeys.toggleMute(),
+      mutationFn: async (chatRoomId?: number) => {
         if (!chatRoomId) {
           throw new Error('chatRoomId is missing');
         }

--- a/src/apis/chat/mutations.ts
+++ b/src/apis/chat/mutations.ts
@@ -1,11 +1,12 @@
 import { mutationOptions } from '@tanstack/react-query';
-import { postAdminChatRoom, postChatMessage, postChatMute, postChatRooms } from '@/apis/chat';
+import { patchChatRoomName, postAdminChatRoom, postChatMessage, postChatMute, postChatRooms } from '@/apis/chat';
 
 export const chatMutationKeys = {
   createRoom: () => ['chat', 'createRoom'] as const,
   createAdminRoom: () => ['chat', 'createAdminRoom'] as const,
   sendMessage: () => ['chat', 'sendMessage'] as const,
   toggleMute: (chatRoomId?: number) => ['chat', 'toggleMute', chatRoomId ?? 'unknown'] as const,
+  updateRoomName: () => ['chat', 'updateRoomName'] as const,
 };
 
 export const chatMutations = {
@@ -34,5 +35,10 @@ export const chatMutations = {
 
         return postChatMute(chatRoomId);
       },
+    }),
+  updateRoomName: () =>
+    mutationOptions({
+      mutationKey: chatMutationKeys.updateRoomName(),
+      mutationFn: ({ chatRoomId, name }: { chatRoomId: number; name: string }) => patchChatRoomName(chatRoomId, name),
     }),
 };

--- a/src/components/layout/Header/components/ChatHeader.tsx
+++ b/src/components/layout/Header/components/ChatHeader.tsx
@@ -58,7 +58,7 @@ function ChatHeader() {
             <button
               type="button"
               disabled={isTogglingMute}
-              onClick={() => void toggleMute()}
+              onClick={() => void toggleMute(numericRoomId)}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                 isMuted ? 'bg-gray-300' : 'bg-primary'
               } disabled:cursor-not-allowed disabled:opacity-60`}

--- a/src/pages/Chat/components/ChatRoomContextMenu.tsx
+++ b/src/pages/Chat/components/ChatRoomContextMenu.tsx
@@ -1,0 +1,62 @@
+import { useRef } from 'react';
+import { cn } from '@/utils/ts/cn';
+
+interface MenuItem {
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}
+
+interface ChatRoomContextMenuProps {
+  x: number;
+  y: number;
+  title: string;
+  items: MenuItem[];
+  onClose: () => void;
+}
+
+export default function ChatRoomContextMenu({ x, y, title, items, onClose }: ChatRoomContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const menuWidth = 160;
+  const menuItemHeight = 44;
+  const menuHeight = items.length * menuItemHeight;
+
+  const adjustedX = x + menuWidth > window.innerWidth ? x - menuWidth : x;
+  const adjustedY = y + menuHeight > window.innerHeight ? y - menuHeight : y;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+      />
+      <div
+        ref={menuRef}
+        className="bg-text-100/80 fixed z-50 h-[159px] w-[161px] overflow-hidden rounded-xl py-3 shadow-lg"
+        style={{ left: adjustedX, top: adjustedY }}
+      >
+        <div className="truncate px-4 py-3 text-[14px] font-bold text-indigo-900">{title}</div>
+        {items.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
+            className={cn(
+              'active:bg-indigo-5 w-full px-4 py-2.5 text-left text-[14px] font-medium',
+              item.danger ? 'text-red-500' : 'text-indigo-700'
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/pages/Chat/components/ChatRoomContextMenu.tsx
+++ b/src/pages/Chat/components/ChatRoomContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import useClickTouchOutside from '@/utils/hooks/useClickTouchOutside';
 import { cn } from '@/utils/ts/cn';
 
 interface MenuItem {
@@ -17,6 +18,7 @@ interface ChatRoomContextMenuProps {
 
 export default function ChatRoomContextMenu({ x, y, title, items, onClose }: ChatRoomContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  useClickTouchOutside(menuRef, onClose);
 
   const menuWidth = 160;
   const menuItemHeight = 44;
@@ -26,37 +28,28 @@ export default function ChatRoomContextMenu({ x, y, title, items, onClose }: Cha
   const adjustedY = y + menuHeight > window.innerHeight ? y - menuHeight : y;
 
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40"
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
-      />
-      <div
-        ref={menuRef}
-        className="bg-text-100/80 fixed z-50 h-[159px] w-[161px] overflow-hidden rounded-xl py-3 shadow-lg"
-        style={{ left: adjustedX, top: adjustedY }}
-      >
-        <div className="truncate px-4 py-3 text-[14px] font-bold text-indigo-900">{title}</div>
-        {items.map((item) => (
-          <button
-            key={item.label}
-            type="button"
-            onClick={() => {
-              item.onClick();
-              onClose();
-            }}
-            className={cn(
-              'active:bg-indigo-5 w-full px-4 py-2.5 text-left text-[14px] font-medium',
-              item.danger ? 'text-red-500' : 'text-indigo-700'
-            )}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-    </>
+    <div
+      ref={menuRef}
+      className="bg-text-100/80 fixed z-50 h-[159px] w-[161px] overflow-hidden rounded-xl py-3 shadow-lg"
+      style={{ left: adjustedX, top: adjustedY }}
+    >
+      <div className="truncate px-4 py-3 text-[14px] font-bold text-indigo-900">{title}</div>
+      {items.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          onClick={() => {
+            item.onClick();
+            onClose();
+          }}
+          className={cn(
+            'active:bg-indigo-5 w-full px-4 py-2.5 text-left text-[14px] font-medium',
+            item.danger ? 'text-red-500' : 'text-indigo-700'
+          )}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
   );
 }

--- a/src/pages/Chat/components/ChatRoomContextMenu.tsx
+++ b/src/pages/Chat/components/ChatRoomContextMenu.tsx
@@ -15,18 +15,18 @@ interface ChatRoomContextMenuProps {
   items: MenuItem[];
   onClose: () => void;
 }
+const MENU_WIDTH = 161;
+const MENU_ITEM_HEIGHT = 44;
+const MENU_HEADER_HEIGHT = 27;
+const MENU_VERTICAL_PADDING = 24;
 
 export default function ChatRoomContextMenu({ x, y, title, items, onClose }: ChatRoomContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   useOutsideTapDismiss(menuRef, onClose);
 
-  const menuWidth = 161;
-  const menuItemHeight = 44;
-  const menuHeaderHeight = 27;
-  const menuVerticalPadding = 24;
-  const menuHeight = menuHeaderHeight + menuVerticalPadding + items.length * menuItemHeight;
+  const menuHeight = MENU_HEADER_HEIGHT + MENU_VERTICAL_PADDING + items.length * MENU_ITEM_HEIGHT;
 
-  const adjustedX = x + menuWidth > window.innerWidth ? x - menuWidth : x;
+  const adjustedX = x + MENU_WIDTH > window.innerWidth ? x - MENU_WIDTH : x;
   const adjustedY = y + menuHeight > window.innerHeight ? y - menuHeight : y;
 
   return (

--- a/src/pages/Chat/components/ChatRoomContextMenu.tsx
+++ b/src/pages/Chat/components/ChatRoomContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import useClickTouchOutside from '@/utils/hooks/useClickTouchOutside';
+import useOutsideTapDismiss from '@/utils/hooks/useOutsideTapDismiss';
 import { cn } from '@/utils/ts/cn';
 
 interface MenuItem {
@@ -18,7 +18,7 @@ interface ChatRoomContextMenuProps {
 
 export default function ChatRoomContextMenu({ x, y, title, items, onClose }: ChatRoomContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
-  useClickTouchOutside(menuRef, onClose);
+  useOutsideTapDismiss(menuRef, onClose);
 
   const menuWidth = 160;
   const menuItemHeight = 44;

--- a/src/pages/Chat/components/ChatRoomContextMenu.tsx
+++ b/src/pages/Chat/components/ChatRoomContextMenu.tsx
@@ -20,9 +20,11 @@ export default function ChatRoomContextMenu({ x, y, title, items, onClose }: Cha
   const menuRef = useRef<HTMLDivElement>(null);
   useOutsideTapDismiss(menuRef, onClose);
 
-  const menuWidth = 160;
+  const menuWidth = 161;
   const menuItemHeight = 44;
-  const menuHeight = items.length * menuItemHeight;
+  const menuHeaderHeight = 27;
+  const menuVerticalPadding = 24;
+  const menuHeight = menuHeaderHeight + menuVerticalPadding + items.length * menuItemHeight;
 
   const adjustedX = x + menuWidth > window.innerWidth ? x - menuWidth : x;
   const adjustedY = y + menuHeight > window.innerHeight ? y - menuHeight : y;
@@ -30,8 +32,8 @@ export default function ChatRoomContextMenu({ x, y, title, items, onClose }: Cha
   return (
     <div
       ref={menuRef}
-      className="bg-text-100/80 fixed z-50 h-[159px] w-[161px] overflow-hidden rounded-xl py-3 shadow-lg"
-      style={{ left: adjustedX, top: adjustedY }}
+      className="bg-text-100/80 fixed z-50 w-[161px] overflow-hidden rounded-xl py-3 shadow-lg"
+      style={{ left: adjustedX, top: adjustedY, height: menuHeight }}
     >
       <div className="truncate px-4 py-3 text-[14px] font-bold text-indigo-900">{title}</div>
       {items.map((item) => (

--- a/src/pages/Chat/hooks/useChat.ts
+++ b/src/pages/Chat/hooks/useChat.ts
@@ -6,6 +6,7 @@ import {
   useSendChatMessageMutation,
   useToggleChatMuteMutation,
   useUpdateChatRoomNameMutation,
+  useDeleteChatRoomMutation,
 } from '@/pages/Chat/hooks/useChatMutations';
 
 const useChat = (chatRoomId?: number) => {
@@ -40,6 +41,8 @@ const useChat = (chatRoomId?: number) => {
 
   const updateRoomNameMutation = useUpdateChatRoomNameMutation();
 
+  const deleteChatRoomMutation = useDeleteChatRoomMutation();
+
   return {
     chatRoomList,
     createChatRoom: createChatRoomMutation.mutateAsync,
@@ -56,6 +59,8 @@ const useChat = (chatRoomId?: number) => {
     isTogglingMute: toggleMuteMutation.isPending,
     updateRoomName: updateRoomNameMutation.mutateAsync,
     isUpdatingRoomName: updateRoomNameMutation.isPending,
+    deleteChatRoom: deleteChatRoomMutation.mutateAsync,
+    isDeletingChatRoom: deleteChatRoomMutation.isPending,
   };
 };
 

--- a/src/pages/Chat/hooks/useChat.ts
+++ b/src/pages/Chat/hooks/useChat.ts
@@ -37,7 +37,7 @@ const useChat = (chatRoomId?: number) => {
 
   const { data: clubMembersData } = useQuery(clubQueries.members(clubId));
 
-  const toggleMuteMutation = useToggleChatMuteMutation(chatRoomId);
+  const toggleMuteMutation = useToggleChatMuteMutation();
 
   const updateRoomNameMutation = useUpdateChatRoomNameMutation();
 

--- a/src/pages/Chat/hooks/useChat.ts
+++ b/src/pages/Chat/hooks/useChat.ts
@@ -5,6 +5,7 @@ import {
   useCreateChatRoomMutation,
   useSendChatMessageMutation,
   useToggleChatMuteMutation,
+  useUpdateChatRoomNameMutation,
 } from '@/pages/Chat/hooks/useChatMutations';
 
 const useChat = (chatRoomId?: number) => {
@@ -37,6 +38,8 @@ const useChat = (chatRoomId?: number) => {
 
   const toggleMuteMutation = useToggleChatMuteMutation(chatRoomId);
 
+  const updateRoomNameMutation = useUpdateChatRoomNameMutation();
+
   return {
     chatRoomList,
     createChatRoom: createChatRoomMutation.mutateAsync,
@@ -51,6 +54,8 @@ const useChat = (chatRoomId?: number) => {
     clubMembers: clubMembersData?.clubMembers ?? [],
     toggleMute: toggleMuteMutation.mutateAsync,
     isTogglingMute: toggleMuteMutation.isPending,
+    updateRoomName: updateRoomNameMutation.mutateAsync,
+    isUpdatingRoomName: updateRoomNameMutation.isPending,
   };
 };
 

--- a/src/pages/Chat/hooks/useChatMutations.ts
+++ b/src/pages/Chat/hooks/useChatMutations.ts
@@ -38,11 +38,11 @@ export const useUpdateChatRoomNameMutation = () => {
   });
 };
 
-export const useToggleChatMuteMutation = (chatRoomId?: number) => {
+export const useToggleChatMuteMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    ...chatMutations.toggleMute(chatRoomId),
+    ...chatMutations.toggleMute(),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: chatQueryKeys.rooms() });
     },

--- a/src/pages/Chat/hooks/useChatMutations.ts
+++ b/src/pages/Chat/hooks/useChatMutations.ts
@@ -27,6 +27,17 @@ export const useSendChatMessageMutation = () => {
   });
 };
 
+export const useUpdateChatRoomNameMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...chatMutations.updateRoomName(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.rooms() });
+    },
+  });
+};
+
 export const useToggleChatMuteMutation = (chatRoomId?: number) => {
   const queryClient = useQueryClient();
 

--- a/src/pages/Chat/hooks/useChatMutations.ts
+++ b/src/pages/Chat/hooks/useChatMutations.ts
@@ -48,3 +48,14 @@ export const useToggleChatMuteMutation = (chatRoomId?: number) => {
     },
   });
 };
+
+export const useDeleteChatRoomMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...chatMutations.deleteRoom(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.rooms() });
+    },
+  });
+};

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -201,22 +201,65 @@ function ChatAdvertisementListItemSkeleton() {
   );
 }
 
+interface ContextMenuProps {
+  x: number;
+  y: number;
+  room: Room;
+}
+
 function ChatListPage() {
-  const { chatRoomList, updateRoomName, deleteChatRoom } = useChat();
-  const [contextMenu, setContextMenu] = useState<{
-    x: number;
-    y: number;
-    room: Room;
-  } | null>(null);
-  const [leaveRoom, setLeaveRoom] = useState<Room | null>(null);
-  const [changeRoomName, setChangeRoomName] = useState<Room | null>(null);
-  const [newRoomName, setNewRoomName] = useState('');
+  const { chatRoomList, updateRoomName, deleteChatRoom, toggleMute } = useChat();
   const rooms = chatRoomList.rooms;
   const advertisementCount = getAdvertisementCount(rooms.length);
   const { advertisements, isLoadingAdvertisements, trackAdvertisementClick } = useAdvertisements({
     advertisementCount,
     scope: 'chat-list',
   });
+
+  const [contextMenu, setContextMenu] = useState<ContextMenuProps | null>(null);
+  const [leaveRoom, setLeaveRoom] = useState<Room | null>(null);
+  const [changeRoomName, setChangeRoomName] = useState<Room | null>(null);
+  const [newRoomName, setNewRoomName] = useState('');
+
+  const changeName = () => {
+    if (!changeRoomName) return;
+    const roomId = changeRoomName.roomId;
+    const normalizedName = newRoomName.trim();
+    setChangeRoomName(null);
+    void updateRoomName({ chatRoomId: roomId, name: normalizedName });
+  };
+
+  const contextMenuItems = (room: Room) => [
+    {
+      label: '채팅방 이름 변경',
+      onClick: () => {
+        setChangeRoomName(room);
+        setNewRoomName(room.roomName);
+      },
+    },
+    {
+      label: room.isMuted ? '알림 켜기' : '알림 끄기',
+      onClick: () => {
+        toggleMute(room.roomId);
+        setContextMenu(null);
+      },
+    },
+    ...(room.chatType === 'DIRECT'
+      ? [{ label: '채팅방 나가기', onClick: () => setLeaveRoom(room), danger: true }]
+      : []),
+  ];
+
+  const deleteChat = async () => {
+    if (!leaveRoom) return;
+    const roomId = leaveRoom.roomId;
+    setLeaveRoom(null);
+    try {
+      await deleteChatRoom(roomId);
+    } catch (error) {
+      console.error('Error leaving chat room:', error);
+    }
+  };
+
   if (rooms.length === 0) {
     return (
       <div className="bg-indigo-0 flex min-h-full flex-col items-center justify-center px-6 py-3 text-center">
@@ -264,15 +307,7 @@ function ChatListPage() {
           <button
             type="button"
             className="bg-primary-500 mr-4 flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
-            onClick={async () => {
-              setLeaveRoom(null);
-              if (!leaveRoom) return;
-              try {
-                await deleteChatRoom(leaveRoom.roomId);
-              } catch (error) {
-                console.error('Error leaving chat room:', error);
-              }
-            }}
+            onClick={deleteChat}
           >
             나가기
           </button>
@@ -281,7 +316,7 @@ function ChatListPage() {
       <BottomModal isOpen={changeRoomName !== null} onClose={() => setChangeRoomName(null)} className="h-59">
         <div className="flex items-center px-4 py-4">
           <button type="button" aria-label="닫기" onClick={() => setChangeRoomName(null)}>
-            <ChevronLeftIcon className="size-6" />
+            <ChevronLeftIcon />
           </button>
           <div className="px-30 text-center font-semibold">이름 변경</div>
         </div>
@@ -296,13 +331,7 @@ function ChatListPage() {
           <button
             type="button"
             className="bg-primary-500 w-[343px] flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
-            onClick={() => {
-              if (!changeRoomName) return;
-              const roomId = changeRoomName.roomId;
-              const normalizedName = newRoomName.trim();
-              setChangeRoomName(null);
-              void updateRoomName({ chatRoomId: roomId, name: normalizedName });
-            }}
+            onClick={changeName}
           >
             확인
           </button>
@@ -313,21 +342,7 @@ function ChatListPage() {
           x={contextMenu.x}
           y={contextMenu.y}
           title={contextMenu.room.roomName}
-          items={[
-            {
-              label: '채팅방 이름 변경',
-              onClick: () => {
-                setChangeRoomName(contextMenu.room);
-                setNewRoomName(contextMenu.room.roomName);
-              },
-            },
-            { label: '알림 끄기', onClick: () => {} },
-            {
-              label: '채팅방 나가기',
-              onClick: () => setLeaveRoom(contextMenu.room),
-              danger: true,
-            },
-          ]}
+          items={contextMenuItems(contextMenu.room)}
           onClose={() => setContextMenu(null)}
         />
       )}

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -202,7 +202,7 @@ function ChatAdvertisementListItemSkeleton() {
 }
 
 function ChatListPage() {
-  const { chatRoomList, updateRoomName } = useChat();
+  const { chatRoomList, updateRoomName, deleteChatRoom } = useChat();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -264,7 +264,11 @@ function ChatListPage() {
           <button
             type="button"
             className="bg-primary-500 mr-4 flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
-            onClick={() => setLeaveRoom(null)}
+            onClick={() => {
+              setLeaveRoom(null);
+              if (!leaveRoom) return;
+              deleteChatRoom(leaveRoom.roomId);
+            }}
           >
             나가기
           </button>

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -92,7 +92,7 @@ function ChatRoomListItem({ room, onLongPress }: ChatRoomListItemProps) {
     <Link
       {...longPress}
       to={`${room.roomId}`}
-      className="active:bg-indigo-5 flex items-center gap-3 bg-white px-5 py-3 transition-colors"
+      className="active:bg-indigo-5 user-select-none flex touch-pan-y items-center gap-3 bg-white px-5 py-3 transition-colors"
     >
       <ChatRoomAvatar roomImageUrl={room.roomImageUrl} />
 

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -264,10 +264,14 @@ function ChatListPage() {
           <button
             type="button"
             className="bg-primary-500 mr-4 flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
-            onClick={() => {
+            onClick={async () => {
               setLeaveRoom(null);
               if (!leaveRoom) return;
-              deleteChatRoom(leaveRoom.roomId);
+              try {
+                await deleteChatRoom(leaveRoom.roomId);
+              } catch (error) {
+                console.error('Error leaving chat room:', error);
+              }
             }}
           >
             나가기
@@ -295,8 +299,9 @@ function ChatListPage() {
             onClick={() => {
               if (!changeRoomName) return;
               const roomId = changeRoomName.roomId;
+              const normalizedName = newRoomName.trim();
               setChangeRoomName(null);
-              void updateRoomName({ chatRoomId: roomId, name: newRoomName });
+              void updateRoomName({ chatRoomId: roomId, name: normalizedName });
             }}
           >
             확인

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -92,7 +92,7 @@ function ChatRoomListItem({ room, onLongPress }: ChatRoomListItemProps) {
     <Link
       {...longPress}
       to={`${room.roomId}`}
-      className="active:bg-indigo-5 user-select-none flex touch-pan-y items-center gap-3 bg-white px-5 py-3 transition-colors"
+      className="active:bg-indigo-5 flex touch-pan-y items-center gap-3 bg-white px-5 py-3 transition-colors select-none"
     >
       <ChatRoomAvatar roomImageUrl={room.roomImageUrl} />
 
@@ -221,12 +221,16 @@ function ChatListPage() {
   const [changeRoomName, setChangeRoomName] = useState<Room | null>(null);
   const [newRoomName, setNewRoomName] = useState('');
 
-  const changeName = () => {
+  const changeName = async () => {
     if (!changeRoomName) return;
     const roomId = changeRoomName.roomId;
     const normalizedName = newRoomName.trim();
+    try {
+      await updateRoomName({ chatRoomId: roomId, name: normalizedName });
+    } catch (error) {
+      console.error('Error updating room name:', error);
+    }
     setChangeRoomName(null);
-    void updateRoomName({ chatRoomId: roomId, name: normalizedName });
   };
 
   const contextMenuItems = (room: Room) => [

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1,11 +1,16 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { Advertisement } from '@/apis/advertisement/entity';
 import type { Room } from '@/apis/chat/entity';
 import BellOffIcon from '@/assets/svg/bell-off.svg';
+import ChevronLeftIcon from '@/assets/svg/chevron-left.svg';
 import PersonIcon from '@/assets/svg/person.svg';
+import BottomModal from '@/components/common/BottomModal';
+import Modal from '@/components/common/Modal';
 import BottomOverlaySpacer from '@/components/layout/BottomOverlaySpacer';
 import { useAdvertisements } from '@/utils/hooks/useAdvertisements';
+import { useLongPress } from '@/utils/hooks/useLongPress';
+import ChatRoomContextMenu from './components/ChatRoomContextMenu';
 import useChat from './hooks/useChat';
 
 const DEFAULT_LAST_MESSAGE = '동아리에 궁금한 점을 물어보세요';
@@ -70,13 +75,22 @@ function ChatRoomAvatar({ roomImageUrl }: Pick<Room, 'roomImageUrl'>) {
   );
 }
 
-function ChatRoomListItem({ room }: { room: Room }) {
+interface ChatRoomListItemProps {
+  room: Room;
+  onLongPress: (x: number, y: number, room: Room) => void;
+}
+
+function ChatRoomListItem({ room, onLongPress }: ChatRoomListItemProps) {
   const isGroup = room.chatType === 'GROUP';
   const hasUnreadMessage = room.unreadCount > 0;
   const previewMessage = room.lastMessage?.trim() || DEFAULT_LAST_MESSAGE;
+  const longPress = useLongPress({
+    onLongPress: (x: number, y: number) => onLongPress(x, y, room),
+  });
 
   return (
     <Link
+      {...longPress}
       to={`${room.roomId}`}
       className="active:bg-indigo-5 flex items-center gap-3 bg-white px-5 py-3 transition-colors"
     >
@@ -188,14 +202,21 @@ function ChatAdvertisementListItemSkeleton() {
 }
 
 function ChatListPage() {
-  const { chatRoomList } = useChat();
+  const { chatRoomList, updateRoomName } = useChat();
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    room: Room;
+  } | null>(null);
+  const [leaveRoom, setLeaveRoom] = useState<Room | null>(null);
+  const [changeRoomName, setChangeRoomName] = useState<Room | null>(null);
+  const [newRoomName, setNewRoomName] = useState('');
   const rooms = chatRoomList.rooms;
   const advertisementCount = getAdvertisementCount(rooms.length);
   const { advertisements, isLoadingAdvertisements, trackAdvertisementClick } = useAdvertisements({
     advertisementCount,
     scope: 'chat-list',
   });
-
   if (rooms.length === 0) {
     return (
       <div className="bg-indigo-0 flex min-h-full flex-col items-center justify-center px-6 py-3 text-center">
@@ -215,7 +236,7 @@ function ChatListPage() {
 
           return (
             <Fragment key={room.roomId}>
-              <ChatRoomListItem room={room} />
+              <ChatRoomListItem room={room} onLongPress={(x, y, room) => setContextMenu({ x, y, room })} />
               {advertisement && (
                 <ChatAdvertisementListItem advertisement={advertisement} onClick={trackAdvertisementClick} />
               )}
@@ -227,6 +248,80 @@ function ChatListPage() {
         })}
         <BottomOverlaySpacer gap={24} />
       </div>
+      <Modal isOpen={leaveRoom !== null} onClose={() => setLeaveRoom(null)} className="h-[172px] w-[341px] rounded-2xl">
+        <div className="px-6 py-6 text-center">
+          <p className="text-text-700 mb-5 text-[16px] font-bold">채팅방 나가기</p>
+          <p className="text-text-500 mt-2 text-[14px]">{leaveRoom?.roomName} 채팅방을 나가시겠어요?</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="ml-4 h-11 w-37 flex-1 cursor-pointer rounded-[10px] border border-[#69BFDF] py-4 text-[14px] font-bold text-[#69BFDF]"
+            onClick={() => setLeaveRoom(null)}
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            className="bg-primary-500 mr-4 flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
+            onClick={() => setLeaveRoom(null)}
+          >
+            나가기
+          </button>
+        </div>
+      </Modal>
+      <BottomModal isOpen={changeRoomName !== null} onClose={() => setChangeRoomName(null)} className="h-59">
+        <div className="flex items-center px-4 py-4">
+          <button type="button" aria-label="닫기" onClick={() => setChangeRoomName(null)}>
+            <ChevronLeftIcon className="size-6" />
+          </button>
+          <div className="px-30 text-center font-semibold">이름 변경</div>
+        </div>
+        <div className="flex w-full flex-col items-center gap-6">
+          <input
+            type="text"
+            value={newRoomName}
+            onChange={(e) => setNewRoomName(e.target.value)}
+            className="text-text-700 mt-11 h-[50px] w-[343px] rounded-2xl border border-indigo-50 text-center"
+            placeholder="변경할 채팅방명을 입력해주세요."
+          />
+          <button
+            type="button"
+            className="bg-primary-500 w-[343px] flex-1 cursor-pointer rounded-[10px] py-4 text-[14px] font-medium text-white"
+            onClick={() => {
+              if (!changeRoomName) return;
+              const roomId = changeRoomName.roomId;
+              setChangeRoomName(null);
+              void updateRoomName({ chatRoomId: roomId, name: newRoomName });
+            }}
+          >
+            확인
+          </button>
+        </div>
+      </BottomModal>
+      {contextMenu && (
+        <ChatRoomContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          title={contextMenu.room.roomName}
+          items={[
+            {
+              label: '채팅방 이름 변경',
+              onClick: () => {
+                setChangeRoomName(contextMenu.room);
+                setNewRoomName(contextMenu.room.roomName);
+              },
+            },
+            { label: '알림 끄기', onClick: () => {} },
+            {
+              label: '채팅방 나가기',
+              onClick: () => setLeaveRoom(contextMenu.room),
+              danger: true,
+            },
+          ]}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/utils/hooks/useLongPress.ts
+++ b/src/utils/hooks/useLongPress.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef } from 'react';
+
+interface LongPressOptions {
+  delay?: number;
+  onLongPress: (x: number, y: number) => void;
+}
+
+export function useLongPress({ delay = 500, onLongPress }: LongPressOptions) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const start = useCallback(
+    (e: React.TouchEvent) => {
+      const touch = e.touches[0];
+      timerRef.current = setTimeout(() => {
+        onLongPress(touch.clientX, touch.clientY);
+      }, delay);
+    },
+    [delay, onLongPress]
+  );
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return {
+    onTouchStart: start,
+    onTouchEnd: cancel,
+    onTouchMove: cancel,
+  };
+}

--- a/src/utils/hooks/useLongPress.ts
+++ b/src/utils/hooks/useLongPress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 
 interface LongPressOptions {
   delay?: number;
@@ -7,27 +7,81 @@ interface LongPressOptions {
 
 export function useLongPress({ delay = 500, onLongPress }: LongPressOptions) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const didLongPressRef = useRef(false);
 
-  const start = useCallback(
-    (e: React.TouchEvent) => {
-      const touch = e.touches[0];
-      timerRef.current = setTimeout(() => {
-        onLongPress(touch.clientX, touch.clientY);
-      }, delay);
-    },
-    [delay, onLongPress]
-  );
+  const clearTimer = () => {
+    if (!timerRef.current) return;
 
-  const cancel = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  };
+
+  const cancel = () => {
+    clearTimer();
+    pointerIdRef.current = null;
+    startPointRef.current = null;
+  };
+
+  const start = (e: React.PointerEvent) => {
+    if (e.pointerType !== 'touch') return;
+
+    cancel();
+    didLongPressRef.current = false;
+    pointerIdRef.current = e.pointerId;
+    startPointRef.current = { x: e.clientX, y: e.clientY };
+
+    timerRef.current = setTimeout(() => {
+      didLongPressRef.current = true;
+      onLongPress(e.clientX, e.clientY);
+      clearTimer();
+    }, delay);
+  };
+
+  const move = (e: React.PointerEvent) => {
+    if (e.pointerType !== 'touch') return;
+    if (pointerIdRef.current !== e.pointerId) return;
+    if (!startPointRef.current) return;
+
+    const deltaX = Math.abs(e.clientX - startPointRef.current.x);
+    const deltaY = Math.abs(e.clientY - startPointRef.current.y);
+
+    if (deltaX > 8 || deltaY > 8) {
+      cancel();
     }
-  }, []);
+  };
+
+  const end = (e: React.PointerEvent) => {
+    if (e.pointerType !== 'touch') return;
+    if (pointerIdRef.current !== e.pointerId) return;
+
+    if (didLongPressRef.current) {
+      e.preventDefault();
+    }
+
+    cancel();
+  };
+
+  const handleClickCapture = (e: React.MouseEvent) => {
+    if (!didLongPressRef.current) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    didLongPressRef.current = false;
+  };
+
+  const preventNativeContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+  };
 
   return {
-    onTouchStart: start,
-    onTouchEnd: cancel,
-    onTouchMove: cancel,
+    onPointerDown: start,
+    onPointerMove: move,
+    onPointerUp: end,
+    onPointerCancel: cancel,
+    onPointerLeave: cancel,
+    onClickCapture: handleClickCapture,
+    onContextMenu: preventNativeContextMenu,
   };
 }

--- a/src/utils/hooks/useLongPress.ts
+++ b/src/utils/hooks/useLongPress.ts
@@ -5,7 +5,8 @@ interface LongPressOptions {
   onLongPress: (x: number, y: number) => void;
 }
 
-export function useLongPress({ delay = 500, onLongPress }: LongPressOptions) {
+const LONG_PRESS_TIME = 500;
+export function useLongPress({ delay = LONG_PRESS_TIME, onLongPress }: LongPressOptions) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pointerIdRef = useRef<number | null>(null);
   const startPointRef = useRef<{ x: number; y: number } | null>(null);

--- a/src/utils/hooks/useOutsideTapDismiss.ts
+++ b/src/utils/hooks/useOutsideTapDismiss.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+const TAP_MOVE_THRESHOLD_PX = 8;
+const SUPPRESS_CLICK_TIMEOUT_MS = 400;
+
+export default function useOutsideTapDismiss<T extends HTMLElement>(ref: RefObject<T | null>, onDismiss: () => void) {
+  const onDismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    let activePointerId: number | null = null;
+    let startX = 0;
+    let startY = 0;
+
+    const resetGesture = () => {
+      activePointerId = null;
+      startX = 0;
+      startY = 0;
+    };
+
+    const suppressNextClick = () => {
+      let timeoutId = 0;
+
+      const handleClick = (event: MouseEvent) => {
+        window.clearTimeout(timeoutId);
+        window.removeEventListener('click', handleClick, true);
+        event.preventDefault();
+        event.stopPropagation();
+      };
+
+      timeoutId = window.setTimeout(() => {
+        window.removeEventListener('click', handleClick, true);
+      }, SUPPRESS_CLICK_TIMEOUT_MS);
+
+      window.addEventListener('click', handleClick, true);
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const element = ref.current;
+
+      if (!element) return;
+      if (!event.isPrimary) return;
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      if (event.target instanceof Node && element.contains(event.target)) return;
+
+      activePointerId = event.pointerId;
+      startX = event.clientX;
+      startY = event.clientY;
+
+      event.stopPropagation();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (activePointerId !== event.pointerId) return;
+
+      const deltaX = Math.abs(event.clientX - startX);
+      const deltaY = Math.abs(event.clientY - startY);
+
+      if (deltaX <= TAP_MOVE_THRESHOLD_PX && deltaY <= TAP_MOVE_THRESHOLD_PX) return;
+
+      resetGesture();
+      onDismissRef.current();
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (activePointerId !== event.pointerId) return;
+
+      resetGesture();
+      suppressNextClick();
+      onDismissRef.current();
+    };
+
+    const handlePointerCancel = (event: PointerEvent) => {
+      if (activePointerId !== event.pointerId) return;
+
+      resetGesture();
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown, true);
+    window.addEventListener('pointermove', handlePointerMove, true);
+    window.addEventListener('pointerup', handlePointerUp, true);
+    window.addEventListener('pointercancel', handlePointerCancel, true);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true);
+      window.removeEventListener('pointermove', handlePointerMove, true);
+      window.removeEventListener('pointerup', handlePointerUp, true);
+      window.removeEventListener('pointercancel', handlePointerCancel, true);
+    };
+  }, [ref]);
+}


### PR DESCRIPTION
## ✨ 요약
- 사용자가 자신에게 보이는 채팅방의 이름을 수정하거나 채팅방을 나갈 수 있는 기능을 구현했습니다.

## 😎 해결한 이슈
close #255 

## ✅ 작업 내용
- patchChatRoom, DeleteChatRoom API 추가
- 채팅창 목록에서 채팅방을 길게 누를시 contextMessage 표시
- 사용자 화면에서의 채팅방 이름을 원하는 값으로 설정 가능
- 채팅방 이름 수정시 공백을 입력하면 기본값으로 저장
- 채팅방 나가기를 선택시 해당 채팅방 삭제
- 알림 끄기/켜기 메뉴에 toggleMute 연결

## 🧪 테스트
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 목록에서 롱프레스하여 컨텍스트 메뉴 열기 지원
  * 컨텍스트 메뉴에서 채팅방 이름 변경 및 채팅방 나가기(삭제) 기능 추가
* **개선**
  * 컨텍스트 메뉴 위치 보정 및 항목별 위험 표시(삭제는 붉은색) 적용
  * 롱프레스 제스처와 외부 탭으로 메뉴/모달 닫기 동작 안정화
  * 음소거 토글이 현재 방을 명확히 대상으로 동작하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->