### PR TITLE
[refactor] 가이드 페이지 이미지 변경 및 구조 개선

### DIFF
--- a/src/pages/Guide/guideData.ts
+++ b/src/pages/Guide/guideData.ts
@@ -4,10 +4,15 @@ export interface GuideItem {
   duration?: number;
 }
 
-export const GUIDE_ITEMS = [
-  { id: 1, image: 'https://stage-static.koreatech.in/konect/guide/1-1%EB%B2%88.png', duration: 3000 },
-  { id: 2, image: 'https://stage-static.koreatech.in/konect/guide/2-1%EB%B2%88.png', duration: 3000 },
-  { id: 3, image: 'https://stage-static.koreatech.in/konect/guide/3-1%EB%B2%88.png', duration: 3000 },
-  { id: 4, image: 'https://stage-static.koreatech.in/konect/guide/4%EB%B2%88.png', duration: 3000 },
-  { id: 5, image: 'https://stage-static.koreatech.in/konect/guide/5%EB%B2%88.png', duration: 3000 },
-];
+const GUIDE_IMAGE_BASE_URL = 'https://stage-static.koreatech.in/konect/guide';
+const GUIDE_ITEM_DURATION = 3000;
+
+const GUIDE_IMAGE_FILE_NAMES = ['가이드1.webp', '가이드2.webp', '가이드3.webp', '가이드4.webp', '순공시간_개인별.webp'];
+
+const getGuideImageUrl = (fileName: string) => `${GUIDE_IMAGE_BASE_URL}/${encodeURIComponent(fileName)}`;
+
+export const GUIDE_ITEMS: GuideItem[] = GUIDE_IMAGE_FILE_NAMES.map((fileName, index) => ({
+  id: index + 1,
+  image: getGuideImageUrl(fileName),
+  duration: GUIDE_ITEM_DURATION,
+}));


### PR DESCRIPTION
  ## ✨ 요약
  ```ts
  - 가이드 페이지 이미지 경로를 신규 `.webp` 파일 기준으로 변경했습니다.
  - `GUIDE_ITEMS`를 하드코딩 배열에서 파일명 배열 기반으로 생성하도록 리팩토링했습니다.
  - 이미지 base URL, duration 상수를 분리해 데이터 구조를 정리했습니다.
  - `encodeURIComponent`를 적용해 한글 파일명도 안전하게 URL로 생성되도록 수정했습니다.
```
  <br><br>

  ## 😎 해결한 이슈

  - close #259

  <br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **최적화**
  * 가이드 이미지 형식을 PNG에서 WebP로 업그레이드하여 파일 크기 감소 및 로딩 성능 향상

* **개선사항**
  * 가이드 항목의 데이터 구조 및 관리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->