### PR TITLE
[feat] 타이머 브릿지 추가 및 화면 정책 설정

### DIFF
--- a/src/constants/timer.ts
+++ b/src/constants/timer.ts
@@ -1,0 +1,28 @@
+type TimerDisplayPlatform = 'android' | 'ios' | 'web';
+
+const IOS_TIMER_BRIGHTNESS_LEVEL = 0.35;
+const ANDROID_TIMER_BRIGHTNESS_LEVEL = 0.28;
+
+function getTimerDisplayPlatform(userAgent = navigator.userAgent): TimerDisplayPlatform {
+  if (!window.ReactNativeWebView) return 'web';
+
+  if (/Android/i.test(userAgent)) {
+    return 'android';
+  }
+
+  if (/(iPhone|iPad|iPod|CPU OS)/i.test(userAgent)) {
+    return 'ios';
+  }
+
+  return 'web';
+}
+
+export function getTimerDisplayMode() {
+  const platform = getTimerDisplayPlatform();
+
+  return {
+    keepAwake: true,
+    dimScreen: true,
+    brightnessLevel: platform === 'android' ? ANDROID_TIMER_BRIGHTNESS_LEVEL : IOS_TIMER_BRIGHTNESS_LEVEL,
+  } as const;
+}

--- a/src/constants/timer.ts
+++ b/src/constants/timer.ts
@@ -1,10 +1,18 @@
 type TimerDisplayPlatform = 'android' | 'ios' | 'web';
 
-const IOS_TIMER_BRIGHTNESS_LEVEL = 0.35;
-const ANDROID_TIMER_BRIGHTNESS_LEVEL = 0.28;
+const TIMER_BRIGHTNESS_LEVEL_BY_PLATFORM: Partial<Record<TimerDisplayPlatform, number>> = {
+  android: 0.28,
+  ios: 0.35,
+};
 
-function getTimerDisplayPlatform(userAgent = navigator.userAgent): TimerDisplayPlatform {
-  if (!window.ReactNativeWebView) return 'web';
+function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined' && typeof navigator !== 'undefined';
+}
+
+function getTimerDisplayPlatform(): TimerDisplayPlatform {
+  if (!isBrowserEnvironment() || !window.ReactNativeWebView) return 'web';
+
+  const { userAgent } = navigator;
 
   if (/Android/i.test(userAgent)) {
     return 'android';
@@ -23,6 +31,6 @@ export function getTimerDisplayMode() {
   return {
     keepAwake: true,
     dimScreen: true,
-    brightnessLevel: platform === 'android' ? ANDROID_TIMER_BRIGHTNESS_LEVEL : IOS_TIMER_BRIGHTNESS_LEVEL,
+    brightnessLevel: TIMER_BRIGHTNESS_LEVEL_BY_PLATFORM[platform],
   } as const;
 }

--- a/src/pages/Timer/hooks/useStudyTimer.ts
+++ b/src/pages/Timer/hooks/useStudyTimer.ts
@@ -1,5 +1,9 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { getTimerDisplayMode } from '@/constants/timer';
 import { useStudyTime } from '@/pages/Timer/hooks/useStudyTime';
+import { syncTimerDisplayMode } from '@/utils/ts/nativeBridge';
+
+const TIMER_DISPLAY_MODE = getTimerDisplayMode();
 
 export const useStudyTimer = () => {
   const { studyTime, startStudyTimer, stopStudyTimer, isStarting, isStopping } = useStudyTime();
@@ -68,6 +72,16 @@ export const useStudyTimer = () => {
       window.removeEventListener('blur', stopIfRunning);
     };
   }, []);
+
+  useEffect(() => {
+    syncTimerDisplayMode(isRunning, TIMER_DISPLAY_MODE);
+
+    if (!isRunning) return;
+
+    return () => {
+      syncTimerDisplayMode(false, TIMER_DISPLAY_MODE);
+    };
+  }, [isRunning]);
 
   useEffect(() => {
     if (studyTime?.todayStudyTime != null) {

--- a/src/pages/Timer/hooks/useStudyTimer.ts
+++ b/src/pages/Timer/hooks/useStudyTimer.ts
@@ -74,9 +74,9 @@ export const useStudyTimer = () => {
   }, []);
 
   useEffect(() => {
-    syncTimerDisplayMode(isRunning, TIMER_DISPLAY_MODE);
-
     if (!isRunning) return;
+
+    syncTimerDisplayMode(true, TIMER_DISPLAY_MODE);
 
     return () => {
       syncTimerDisplayMode(false, TIMER_DISPLAY_MODE);

--- a/src/utils/ts/nativeBridge.ts
+++ b/src/utils/ts/nativeBridge.ts
@@ -1,7 +1,20 @@
 type BridgeMessage =
   | { type: 'TOKEN_REFRESH'; accessToken: string }
   | { type: 'LOGIN_COMPLETE'; accessToken: string }
-  | { type: 'LOGOUT' };
+  | { type: 'LOGOUT' }
+  | {
+      type: 'TIMER_ACTIVE';
+      keepAwake: boolean;
+      dimScreen: boolean;
+      brightnessLevel?: number;
+    }
+  | { type: 'TIMER_INACTIVE' };
+
+interface TimerDisplayModeOptions {
+  brightnessLevel?: number;
+  dimScreen?: boolean;
+  keepAwake?: boolean;
+}
 
 export function postNativeMessage(message: BridgeMessage): void {
   try {
@@ -9,4 +22,18 @@ export function postNativeMessage(message: BridgeMessage): void {
   } catch {
     // 브릿지 전달 실패가 앱 흐름을 중단시키지 않도록 무시
   }
+}
+
+export function syncTimerDisplayMode(isRunning: boolean, options: TimerDisplayModeOptions = {}): void {
+  if (isRunning) {
+    postNativeMessage({
+      type: 'TIMER_ACTIVE',
+      keepAwake: options.keepAwake ?? true,
+      dimScreen: options.dimScreen ?? true,
+      brightnessLevel: options.brightnessLevel,
+    });
+    return;
+  }
+
+  postNativeMessage({ type: 'TIMER_INACTIVE' });
 }


### PR DESCRIPTION
## ✨ 요약

```ts
- 타이머 실행 상태를 React Native WebView 브리지 메시지로 전달하도록 추가했습니다.
- 타이머 브리지 메시지에 keepAwake, dimScreen, brightnessLevel 옵션을 포함했습니다.
- 플랫폼별 타이머 화면 정책 기본값을 웹 상수로 분리했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #269

<br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 타이머 실행 중 모바일에서 화면 밝기 조절 및 화면 켜짐 유지 기능 추가
  * 타이머 시작/종료 시 네이티브 쪽으로 디스플레이 모드 동기화 추가(실행 시 활성화, 중단/언마운트 시 해제)
  * Android/iOS 및 웹 환경에 따라 적절한 밝기 설정을 자동으로 선택하여 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->