### PR TITLE
[feat] 타이머 동작 중 페이지 이동 및 뒤로가기 확인 단계 추가

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,10 @@ interface Window {
   APP_VERSION?: string;
 }
 
+interface WindowEventMap {
+  KONECT_NATIVE_BACK_REQUEST: Event;
+}
+
 interface ImportMetaEnv {
   readonly VITE_API_PATH: string;
   readonly VITE_SENTRY_DSN?: string;

--- a/src/pages/Timer/hooks/useTimerExitGuard.ts
+++ b/src/pages/Timer/hooks/useTimerExitGuard.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useBeforeUnload, useLocation, useNavigate } from 'react-router-dom';
+import { requestNativeBackNavigation } from '@/utils/ts/nativeBridge';
+
+const NATIVE_BACK_REQUEST_EVENT = 'KONECT_NATIVE_BACK_REQUEST';
+
+interface UseTimerExitGuardParams {
+  isRunning: boolean;
+  stop: () => Promise<void>;
+}
+
+type PendingNavigation = { type: 'href'; nextHref: string; replace?: boolean } | { type: 'native-back' };
+
+function getNavigationHref(anchor: HTMLAnchorElement): string | null {
+  if (!anchor.href || anchor.target === '_blank' || anchor.hasAttribute('download')) {
+    return null;
+  }
+
+  const nextUrl = new URL(anchor.href, window.location.href);
+  if (nextUrl.origin !== window.location.origin) {
+    return null;
+  }
+
+  const nextHref = `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+  const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+  return nextHref === currentHref ? null : nextHref;
+}
+
+export function useTimerExitGuard({ isRunning, stop }: UseTimerExitGuardParams) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const currentHrefRef = useRef(`${location.pathname}${location.search}${location.hash}`);
+  const pendingNavigationRef = useRef<PendingNavigation | null>(null);
+  const allowNextPopStateRef = useRef(false);
+  const stopRef = useRef(stop);
+  const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    currentHrefRef.current = `${location.pathname}${location.search}${location.hash}`;
+  }, [location.hash, location.pathname, location.search]);
+
+  useEffect(() => {
+    stopRef.current = stop;
+  }, [stop]);
+
+  const openExitConfirm = useCallback((pendingNavigation: PendingNavigation) => {
+    if (pendingNavigationRef.current) return;
+
+    pendingNavigationRef.current = pendingNavigation;
+    setIsExitConfirmOpen(true);
+  }, []);
+
+  const closeExitConfirm = useCallback(() => {
+    pendingNavigationRef.current = null;
+    setIsExitConfirmOpen(false);
+  }, []);
+
+  const confirmExit = useCallback(async () => {
+    const pendingNavigation = pendingNavigationRef.current;
+    if (!pendingNavigation) return;
+
+    pendingNavigationRef.current = null;
+    setIsExitConfirmOpen(false);
+
+    await stopRef.current();
+
+    if (pendingNavigation.type === 'href') {
+      await Promise.resolve(navigate(pendingNavigation.nextHref, { replace: pendingNavigation.replace }));
+      return;
+    }
+
+    allowNextPopStateRef.current = true;
+    requestNativeBackNavigation();
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const anchor = target.closest('a[href]');
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+
+      const nextHref = getNavigationHref(anchor);
+      if (!nextHref) return;
+
+      event.preventDefault();
+      openExitConfirm({ type: 'href', nextHref });
+    };
+
+    document.addEventListener('click', handleDocumentClick, true);
+    return () => {
+      document.removeEventListener('click', handleDocumentClick, true);
+    };
+  }, [isRunning, openExitConfirm]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const handlePopState = () => {
+      if (allowNextPopStateRef.current) {
+        allowNextPopStateRef.current = false;
+        return;
+      }
+
+      const nextHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const currentHref = currentHrefRef.current;
+
+      if (nextHref === currentHref) return;
+
+      window.history.pushState(window.history.state, '', currentHref);
+      openExitConfirm({ type: 'href', nextHref, replace: true });
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [isRunning, openExitConfirm]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const handleNativeBackRequest = () => {
+      openExitConfirm({ type: 'native-back' });
+    };
+
+    window.addEventListener(NATIVE_BACK_REQUEST_EVENT, handleNativeBackRequest);
+    return () => {
+      window.removeEventListener(NATIVE_BACK_REQUEST_EVENT, handleNativeBackRequest);
+    };
+  }, [isRunning, openExitConfirm]);
+
+  useBeforeUnload(
+    (event) => {
+      if (!isRunning) return;
+
+      event.preventDefault();
+      event.returnValue = '';
+    },
+    { capture: true }
+  );
+
+  return {
+    isExitConfirmOpen,
+    closeExitConfirm,
+    confirmExit,
+  };
+}

--- a/src/pages/Timer/hooks/useTimerExitGuard.ts
+++ b/src/pages/Timer/hooks/useTimerExitGuard.ts
@@ -9,7 +9,7 @@ interface UseTimerExitGuardParams {
   stop: () => Promise<void>;
 }
 
-type PendingNavigation = { type: 'href'; nextHref: string; replace?: boolean } | { type: 'native-back' };
+type PendingNavigation = { type: 'href'; nextHref: string } | { type: 'history-back' } | { type: 'native-back' };
 
 function getNavigationHref(anchor: HTMLAnchorElement): string | null {
   if (!anchor.href || anchor.target === '_blank' || anchor.hasAttribute('download')) {
@@ -66,7 +66,13 @@ export function useTimerExitGuard({ isRunning, stop }: UseTimerExitGuardParams) 
     await stopRef.current();
 
     if (pendingNavigation.type === 'href') {
-      navigate(pendingNavigation.nextHref, { replace: pendingNavigation.replace });
+      navigate(pendingNavigation.nextHref);
+      return;
+    }
+
+    if (pendingNavigation.type === 'history-back') {
+      allowNextPopStateRef.current = true;
+      window.history.back();
       return;
     }
 
@@ -129,7 +135,7 @@ export function useTimerExitGuard({ isRunning, stop }: UseTimerExitGuardParams) 
       }
 
       window.history.pushState(window.history.state, '', currentHref);
-      openExitConfirm({ type: 'href', nextHref, replace: true });
+      openExitConfirm({ type: 'history-back' });
     };
 
     window.addEventListener('popstate', handlePopState);

--- a/src/pages/Timer/hooks/useTimerExitGuard.ts
+++ b/src/pages/Timer/hooks/useTimerExitGuard.ts
@@ -66,7 +66,7 @@ export function useTimerExitGuard({ isRunning, stop }: UseTimerExitGuardParams) 
     await stopRef.current();
 
     if (pendingNavigation.type === 'href') {
-      await Promise.resolve(navigate(pendingNavigation.nextHref, { replace: pendingNavigation.replace }));
+      navigate(pendingNavigation.nextHref, { replace: pendingNavigation.replace });
       return;
     }
 
@@ -121,6 +121,12 @@ export function useTimerExitGuard({ isRunning, stop }: UseTimerExitGuardParams) 
       const currentHref = currentHrefRef.current;
 
       if (nextHref === currentHref) return;
+
+      if (pendingNavigationRef.current) {
+        allowNextPopStateRef.current = true;
+        window.history.go(1);
+        return;
+      }
 
       window.history.pushState(window.history.state, '', currentHref);
       openExitConfirm({ type: 'href', nextHref, replace: true });

--- a/src/pages/Timer/index.tsx
+++ b/src/pages/Timer/index.tsx
@@ -2,10 +2,12 @@ import { useRef, useState, useTransition } from 'react';
 import type { StudyRankingParams } from '@/apis/studyTime/entity';
 import BottomSheet, { type SheetPosition } from '@/components/common/BottomSheet';
 import Dropdown from '@/components/common/Dropdown';
+import Modal from '@/components/common/Modal';
 import { useLayoutElementsContext } from '@/contexts/useLayoutElementsContext';
 import RankingList from '@/pages/Timer/components/RankingList';
 import TimerButton from '@/pages/Timer/components/TimerButton';
 import { useStudyTimer } from '@/pages/Timer/hooks/useStudyTimer';
+import { useTimerExitGuard } from '@/pages/Timer/hooks/useTimerExitGuard';
 import { useTimerLayout } from '@/pages/Timer/hooks/useTimerLayout';
 import { cn } from '@/utils/ts/cn';
 
@@ -23,7 +25,7 @@ const SORT_OPTIONS = [
 ] as const;
 
 function TimerPage() {
-  const { todayAccumulatedSeconds, sessionStartMs, isRunning, toggle, isStarting, isStopping } = useStudyTimer();
+  const { todayAccumulatedSeconds, sessionStartMs, isRunning, toggle, stop, isStarting, isStopping } = useStudyTimer();
   const { bottomOverlayInsetPx } = useLayoutElementsContext();
   const timerSectionRef = useRef<HTMLDivElement>(null);
 
@@ -32,6 +34,7 @@ function TimerPage() {
   const [sort, setSort] = useState<StudyRankingParams['sort']>('MONTHLY');
   const [sheetPosition, setSheetPosition] = useState<SheetPosition>('half');
   const [autoExpandResetKey, setAutoExpandResetKey] = useState(0);
+  const { isExitConfirmOpen, closeExitConfirm, confirmExit } = useTimerExitGuard({ isRunning, stop });
 
   const tabs: TabType[] = ['동아리', '학번', '개인'];
   const isBusy = isStarting || isStopping;
@@ -112,6 +115,31 @@ function TimerPage() {
           </div>
         )}
       </BottomSheet>
+
+      <Modal isOpen={isExitConfirmOpen} onClose={closeExitConfirm} className="rounded-2xl px-4 py-5">
+        <div className="text-text-700 flex flex-col gap-5 text-center text-[15px] leading-[1.6]">
+          <p className="font-semibold">타이머 종료</p>
+          <p className="font-medium">타이머를 종료하고 페이지를 이동할까요?</p>
+          <div className="flex gap-2 text-[15px] leading-5.5 font-bold">
+            <button
+              type="button"
+              className="border-primary-500 text-primary-500 flex-1 cursor-pointer rounded-[10px] border py-2.75"
+              onClick={closeExitConfirm}
+              disabled={isStopping}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              className="bg-primary-500 border-primary-500 flex-1 cursor-pointer rounded-[10px] border text-white disabled:opacity-60"
+              onClick={() => void confirmExit()}
+              disabled={isStopping}
+            >
+              종료
+            </button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/utils/ts/nativeBridge.ts
+++ b/src/utils/ts/nativeBridge.ts
@@ -8,7 +8,8 @@ type BridgeMessage =
       dimScreen: boolean;
       brightnessLevel?: number;
     }
-  | { type: 'TIMER_INACTIVE' };
+  | { type: 'TIMER_INACTIVE' }
+  | { type: 'NAVIGATE_BACK' };
 
 interface TimerDisplayModeOptions {
   brightnessLevel?: number;
@@ -36,4 +37,8 @@ export function syncTimerDisplayMode(isRunning: boolean, options: TimerDisplayMo
   }
 
   postNativeMessage({ type: 'TIMER_INACTIVE' });
+}
+
+export function requestNativeBackNavigation(): void {
+  postNativeMessage({ type: 'NAVIGATE_BACK' });
 }


### PR DESCRIPTION
## ✨ 요약
- 타이머 동작 중 내부 페이지 이동과 브라우저 뒤로가기를 공용 모달로 확인하도록 추가했습니다.
- 네이티브 뒤로가기 요청을 웹 브리지로 받아 같은 확인 플로우를 타도록 연동했습니다.
- 새로고침 및 탭 닫기는 브라우저 기본 unload 경고를 유지합니다.

## 😎 해결한 이슈
- close #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 타이머 실행 중 페이지 종료 시 확인 모달을 추가했습니다. 링크 클릭, 브라우저 뒤로가기, 탭 닫기 시도 등에서 종료 여부를 묻습니다.
  * 네이티브 앱의 뒤로가기 요청을 앱 내 확인 흐름과 연동하여 처리하도록 지원했습니다.
  * 종료 동작 처리 중에는 확인 모달 버튼을 비활성화해 중복 동작을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->