### PR TITLE
[refactor] 불필요한 useEffect 제거

### DIFF
--- a/src/apis/studyTime/hooks.ts
+++ b/src/apis/studyTime/hooks.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { StudyTimeSummaryResponse } from '@/apis/studyTime/entity';
 import { studyTimeMutations } from '@/apis/studyTime/mutations';
 import { studyTimeQueryKeys } from '@/apis/studyTime/queries';
 import { API_ERROR_CODES, isApiError } from '@/utils/ts/error/apiError';
@@ -8,7 +9,17 @@ export const useStopStudyTimerMutation = () => {
 
   return useMutation({
     ...studyTimeMutations.stopTimer(),
-    onSuccess: async () => {
+    onSuccess: async (response) => {
+      queryClient.setQueryData<StudyTimeSummaryResponse>(studyTimeQueryKeys.summary(), (previousData) => {
+        const nextSummary = {
+          todayStudyTime: response.dailySeconds,
+          monthlyStudyTime: response.monthlySeconds,
+          totalStudyTime: response.totalSeconds,
+        };
+
+        return previousData ? { ...previousData, ...nextSummary } : nextSummary;
+      });
+
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: studyTimeQueryKeys.summary() }),
         queryClient.invalidateQueries({ queryKey: studyTimeQueryKeys.rankings() }),

--- a/src/apis/studyTime/hooks.ts
+++ b/src/apis/studyTime/hooks.ts
@@ -21,7 +21,6 @@ export const useStopStudyTimerMutation = () => {
       });
 
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: studyTimeQueryKeys.summary() }),
         queryClient.invalidateQueries({ queryKey: studyTimeQueryKeys.rankings() }),
         queryClient.invalidateQueries({ queryKey: studyTimeQueryKeys.myRankings() }),
       ]);

--- a/src/pages/Club/Application/clubFeePage.tsx
+++ b/src/pages/Club/Application/clubFeePage.tsx
@@ -1,22 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import { clubQueries } from '@/apis/club/queries';
 import WarningCircleIcon from '@/assets/svg/warning-circle.svg';
 import Card from '@/components/common/Card';
 import ImageUploader, { useImageUploader } from '@/components/common/ImageUploader';
 import Portal from '@/components/common/Portal';
+import RouteLoadingFallback from '@/components/common/RouteLoadingFallback';
 import { useClubApplicationStore } from '@/stores/clubApplicationStore';
 import useBooleanState from '@/utils/hooks/useBooleanState';
 import AccountInfoCard from './components/AccountInfo';
 import useApplyToClub from './hooks/useApplyToClub';
 
-function ClubFeePage() {
-  const { clubId } = useParams();
-  const navigate = useNavigate();
-  const { data: clubFee } = useSuspenseQuery(clubQueries.fee(Number(clubId)));
-  const { applyToClub, isPending: isApplyingToClub } = useApplyToClub(Number(clubId));
-  const { answers, clubId: storedClubId } = useClubApplicationStore();
+interface ClubFeePageContentProps {
+  answers: ReturnType<typeof useClubApplicationStore.getState>['answers'];
+  clubIdNumber: number;
+}
+
+function ClubFeePageContent({ answers, clubIdNumber }: ClubFeePageContentProps) {
+  const { data: clubFee } = useSuspenseQuery(clubQueries.fee(clubIdNumber));
+  const { applyToClub, isPending: isApplyingToClub } = useApplyToClub(clubIdNumber);
   const {
     images,
     isUploadingImages: isUploadingImage,
@@ -36,12 +39,6 @@ function ClubFeePage() {
     const [feePaymentImageUrl] = await uploadImages([selectedImage]);
     await applyToClub({ answers, feePaymentImageUrl });
   };
-
-  useEffect(() => {
-    if (storedClubId == null || storedClubId !== Number(clubId)) {
-      navigate(`/clubs/${clubId}/apply`, { replace: true });
-    }
-  }, [storedClubId, clubId, navigate]);
 
   return (
     <div
@@ -107,6 +104,23 @@ function ClubFeePage() {
       )}
     </div>
   );
+}
+
+function ClubFeePage() {
+  const { clubId } = useParams();
+  const clubIdNumber = Number(clubId);
+  const hasHydratedClubApplication = useClubApplicationStore.persist.hasHydrated();
+  const { answers, clubId: storedClubId } = useClubApplicationStore();
+
+  if (!hasHydratedClubApplication) {
+    return <RouteLoadingFallback />;
+  }
+
+  if (!Number.isFinite(clubIdNumber) || storedClubId == null || storedClubId !== clubIdNumber) {
+    return <Navigate to={clubId ? `/clubs/${clubId}/apply` : '/clubs'} replace />;
+  }
+
+  return <ClubFeePageContent answers={answers} clubIdNumber={clubIdNumber} />;
 }
 
 export default ClubFeePage;

--- a/src/pages/Club/ClubDetail/index.tsx
+++ b/src/pages/Club/ClubDetail/index.tsx
@@ -1,7 +1,7 @@
-import { Activity, useEffect } from 'react';
+import { Activity } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { clubQueries } from '@/apis/club/queries';
 import useScrollToTop from '@/utils/hooks/useScrollToTop';
 import ClubAccount from './components/ClubAccount';
@@ -9,20 +9,11 @@ import ClubIntro from './components/ClubIntro';
 import ClubMemberTab from './components/ClubMember';
 import ClubRecruit from './components/ClubRecruitment';
 
-const SCROLL_RESTORE_KEY = 'clubList_shouldRestore';
-
 type TabType = 'recruitment' | 'intro' | 'members' | 'account';
 
 function ClubDetail() {
   useScrollToTop();
   const { clubId } = useParams();
-  const location = useLocation();
-
-  useEffect(() => {
-    if (location.state?.from === 'clubList') {
-      sessionStorage.setItem(SCROLL_RESTORE_KEY, 'true');
-    }
-  }, [location.state]);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedTab = searchParams.get('tab');

--- a/src/pages/Club/ClubList/components/ClubCard.tsx
+++ b/src/pages/Club/ClubList/components/ClubCard.tsx
@@ -1,7 +1,9 @@
-import type { Ref } from 'react';
+import type { MouseEvent, Ref } from 'react';
 import { Link } from 'react-router-dom';
 import type { Club } from '@/apis/club/entity';
 import CircleWarningIcon from '@/assets/svg/circle-warning.svg';
+
+const SCROLL_RESTORE_KEY = 'clubList_shouldRestore';
 
 interface ClubCardProps {
   club: Club;
@@ -60,11 +62,19 @@ function ClubCard({ club, itemRef }: ClubCardProps) {
     return null;
   })();
 
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+      return;
+    }
+
+    sessionStorage.setItem(SCROLL_RESTORE_KEY, 'true');
+  };
+
   return (
     <Link
       ref={itemRef}
       to={`/clubs/${club.id}${club.status === 'ONGOING' ? '?tab=recruitment' : ''}`}
-      state={{ from: 'clubList' }}
+      onClick={handleClick}
       className="border-indigo-5 flex w-full items-start gap-3 rounded-2xl border bg-white p-4"
     >
       <img src={club.imageUrl} className="border-indigo-5 h-12 w-12 rounded-sm border object-cover" alt={club.name} />

--- a/src/pages/Manager/ManagedRecruitmentWrite/index.tsx
+++ b/src/pages/Manager/ManagedRecruitmentWrite/index.tsx
@@ -16,7 +16,6 @@ import {
   useUpsertManagedClubRecruitmentMutation,
 } from '@/pages/Manager/hooks/useManagedClubMutations';
 import { useApiErrorToast } from '@/utils/hooks/error/useApiErrorToast';
-import useBooleanState from '@/utils/hooks/useBooleanState';
 import { cn } from '@/utils/ts/cn';
 import { formatDateDot } from '@/utils/ts/datetime/date';
 import { getApiErrorMessage } from '@/utils/ts/error/apiErrorMessage';
@@ -63,11 +62,11 @@ function ManagedRecruitmentWrite() {
   const [isAlwaysRecruiting, setIsAlwaysRecruiting] = useState(false);
   const [isPreparingImages, setIsPreparingImages] = useState(false);
   const [hasHandledExisting, setHasHandledExisting] = useState(false);
-  const { value: isChoiceModalOpen, setTrue: openChoiceModal, setFalse: closeChoiceModal } = useBooleanState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isRecruitmentEnabled = recruitmentEnabledOverride ?? clubSettings?.isRecruitmentEnabled ?? false;
+  const isChoiceModalOpen = existingRecruitment != null && !hasHandledExisting;
 
   const applyExistingRecruitment = () => {
     if (!existingRecruitment) return;
@@ -89,7 +88,6 @@ function ManagedRecruitmentWrite() {
     setIsAlwaysRecruiting(isAlways);
     resetImages(existingRecruitment.images?.map((img) => img.url) ?? []);
     setHasHandledExisting(true);
-    closeChoiceModal();
   };
 
   const startDateTime = combineDateTime(startDate, startTime);
@@ -114,7 +112,10 @@ function ManagedRecruitmentWrite() {
     setIsAlwaysRecruiting(false);
     resetImages();
     setHasHandledExisting(true);
-    closeChoiceModal();
+  };
+
+  const handleCloseChoiceModal = () => {
+    setHasHandledExisting(true);
   };
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -169,12 +170,6 @@ function ManagedRecruitmentWrite() {
   const recruitmentStatusLabel = isRecruitmentEnabled ? '활성화' : '비활성화';
   const isSavingRecruitment = isPending || isSettingsPending;
   const recruitmentActionText = existingRecruitment ? '모집공고 수정' : '모집공고 등록';
-
-  useEffect(() => {
-    if (existingRecruitment && !hasHandledExisting) {
-      openChoiceModal();
-    }
-  }, [existingRecruitment, hasHandledExisting, openChoiceModal]);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -380,7 +375,7 @@ function ManagedRecruitmentWrite() {
       </form>
       <BottomModal
         isOpen={isChoiceModalOpen}
-        onClose={closeChoiceModal}
+        onClose={handleCloseChoiceModal}
         className="overflow-hidden rounded-t-[30px]"
         overlayClassName="bg-black/30"
       >

--- a/src/pages/Timer/hooks/useStudyTimer.ts
+++ b/src/pages/Timer/hooks/useStudyTimer.ts
@@ -8,11 +8,11 @@ const TIMER_DISPLAY_MODE = getTimerDisplayMode();
 export const useStudyTimer = () => {
   const { studyTime, startStudyTimer, stopStudyTimer, isStarting, isStopping } = useStudyTime();
 
-  const [todayAccumulatedSeconds, setTodayAccumulatedSeconds] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [sessionStartMs, setSessionStartMs] = useState<number | null>(null);
 
   const isStopInProgressRef = useRef(false);
+  const todayAccumulatedSeconds = studyTime?.todayStudyTime ?? 0;
 
   const getSessionSeconds = () => {
     if (sessionStartMs === null) return 0;
@@ -38,9 +38,8 @@ export const useStudyTimer = () => {
 
     try {
       const sessionSeconds = getSessionSeconds();
-      const response = await stopStudyTimer({ totalSeconds: sessionSeconds });
+      await stopStudyTimer({ totalSeconds: sessionSeconds });
 
-      setTodayAccumulatedSeconds((prev) => response?.dailySeconds ?? prev + sessionSeconds);
       setSessionStartMs(null);
       setIsRunning(false);
     } catch (error) {
@@ -82,12 +81,6 @@ export const useStudyTimer = () => {
       syncTimerDisplayMode(false, TIMER_DISPLAY_MODE);
     };
   }, [isRunning]);
-
-  useEffect(() => {
-    if (studyTime?.todayStudyTime != null) {
-      setTodayAccumulatedSeconds(studyTime.todayStudyTime);
-    }
-  }, [studyTime?.todayStudyTime]);
 
   const toggle = () => (isRunning ? stop() : start());
 


### PR DESCRIPTION
## ✨ 요약

```ts
렌더 단계에서 바로 판단 가능한 redirect / UI 상태 로직과 서버 상태 복제를 정리하면서 불필요한 useEffect를 제거했습니다.
회비 납부, 타이머, 동아리 상세, 모집공고 작성 흐름의 effect 기반 제어를 이벤트 또는 파생 상태로 바꿨습니다.
```

<br><br>

## 😎 해결한 이슈

- close #286

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 학습 시간 정지 시 요약 데이터가 즉시 캐시에 반영되어 더 빠른 UI 업데이트 제공
  * 타이머 관련 표시가 서버 캐시 기반으로 일관되게 계산되어 상태 동기화 향상
  * 클럽 신청 페이지가 초기화(하이드레이션) 전 로딩 화면을 보여 안정성 향상
  * 렌더 기반 조건부 리다이렉트로 네비게이션 로직 단순화
  * 리스트→상세 이동 시 스크롤 복원 처리가 세션 저장 방식으로 개선
  * 매니저 모집 모달 상태가 선언적 로직으로 전환되어 동작 예측성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->