### PR TITLE
[hotfix] 행사 배너 제거

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -11,7 +11,7 @@ import ScheduleSection, {
   ScheduleSectionSkeleton,
 } from '@/pages/Home/components/ScheduleSection';
 import SectionAsyncBoundary from '@/pages/Home/components/SectionAsyncBoundary';
-import StudyTimerBanner from '@/pages/Home/components/StudyTimerBanner';
+// import StudyTimerBanner from '@/pages/Home/components/StudyTimerBanner';
 
 function Home() {
   return (
@@ -22,9 +22,9 @@ function Home() {
         </SectionAsyncBoundary>
       </section>
 
-      <section aria-label="행사 배너">
+      {/* <section aria-label="행사 배너">
         <StudyTimerBanner />
-      </section>
+      </section> */}
 
       <section>
         <SectionAsyncBoundary fallback={<ScheduleSectionSkeleton />} errorFallback={<ScheduleSectionErrorFallback />}>


### PR DESCRIPTION
## ✨ 요약

```ts
행사 종료에 따른 행사 배너 제거
```

<br><br>

## 😎 해결한 이슈

- close #295

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 홈 페이지에서 스터디 타이머 배너가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->