### PR TITLE
[deploy] 앱 웹 배포 워크플로우 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,20 +15,75 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect deployment targets
+        id: targets
+        run: |
+          changed_files="$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" || true)"
+
+          if [ -z "$changed_files" ]; then
+            changed_files="$(git show --name-only --pretty=format: "${{ github.sha }}" || true)"
+          fi
+
+          app_changed=false
+          web_changed=false
+          shared_changed=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              apps/app/*)
+                app_changed=true
+                ;;
+              apps/web/*)
+                web_changed=true
+                ;;
+              packages/*|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json|tsconfig*.json|eslint.config.js|.github/workflows/deploy.yml)
+                shared_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$shared_changed" = "true" ]; then
+            app_changed=true
+            web_changed=true
+          fi
+
+          deploy_web=$web_changed
+
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            deploy_web=false
+          fi
+
+          {
+            echo "app=$app_changed"
+            echo "web=$deploy_web"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Changed files:"
+          echo "$changed_files"
+          echo "Deploy app: $app_changed"
+          echo "Web changed: $web_changed"
+          echo "Deploy web: $deploy_web"
 
       - name: Setup pnpm
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22.20.0'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Validate runtime secrets
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         run: |
           missing=0
 
@@ -43,7 +98,7 @@ jobs:
           [ "$missing" -eq 0 ] || exit 1
 
       - name: Validate production sourcemap secrets
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'main' && (steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true')
         run: |
           missing=0
           [ -n "${{ secrets.SENTRY_ORG }}" ] || { echo "::error::Missing secret: SENTRY_ORG"; missing=1; }
@@ -52,6 +107,7 @@ jobs:
           [ "$missing" -eq 0 ] || exit 1
 
       - name: Resolve Sentry project
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             echo "SENTRY_PROJECT_FOR_BUILD=${{ secrets.SENTRY_PROJECT }}" >> "$GITHUB_ENV"
@@ -60,6 +116,7 @@ jobs:
           fi
 
       - name: Create .env file
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             {
@@ -86,6 +143,7 @@ jobs:
           fi
 
       - name: Build app
+        if: steps.targets.outputs.app == 'true'
         env:
           CI: true
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -95,6 +153,7 @@ jobs:
         run: pnpm --filter @konect/app build
 
       - name: Build web
+        if: steps.targets.outputs.web == 'true'
         env:
           CI: true
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -104,6 +163,7 @@ jobs:
         run: pnpm --filter @konect/web build
 
       - name: Setup SSH key
+        if: steps.targets.outputs.app == 'true' || steps.targets.outputs.web == 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
@@ -111,6 +171,7 @@ jobs:
           ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SERVER_IP }} 2>/dev/null >> ~/.ssh/known_hosts
 
       - name: Deploy app dist to server
+        if: steps.targets.outputs.app == 'true'
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             DEPLOY_PATH="/opt/konect/prod/client"
@@ -124,12 +185,9 @@ jobs:
             ${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }}:$DEPLOY_PATH
 
       - name: Deploy web dist to server
+        if: steps.targets.outputs.web == 'true'
         run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            DEPLOY_PATH="/opt/konect/prod/web"
-          else
-            DEPLOY_PATH="/opt/konect/stage/web"
-          fi
+          DEPLOY_PATH="/opt/konect/web"
           ssh -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }} "mkdir -p $DEPLOY_PATH"
           rsync -avz --delete-after \
             -e "ssh -p ${{ secrets.SSH_PORT }}" \


### PR DESCRIPTION
## ✨ 요약

```ts
- 변경 파일 경로를 기준으로 app/web 배포 대상을 감지하도록 GitHub Actions를 조정했습니다.
- app과 web 빌드/배포 단계를 각각 조건부로 실행되도록 분리했습니다.
- web 배포 경로를 nginx가 바라보는 /opt/konect/web로 맞추고 main 브랜치에서만 배포되도록 제한했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #304

<br><br>