### PR TITLE
[feat] 최근 본 동아리 조회 기능 구현

### DIFF
--- a/apps/web/src/apis/recentClub/entity.ts
+++ b/apps/web/src/apis/recentClub/entity.ts
@@ -1,0 +1,24 @@
+import type { ClubCategory, ClubCategorySummary, UniversitySummary } from '@/apis/universityClub/entity';
+
+export interface RecentClubListRequestParams {
+  clubIds: number[];
+}
+
+export interface RecentClub {
+  id: number;
+  name: string;
+  imageUrl?: string;
+  category: ClubCategory;
+  categoryName: string;
+  topic?: string;
+  description?: string;
+}
+
+export interface RecentClubListResponse {
+  university: UniversitySummary;
+  totalCount: number;
+  totalPage: number;
+  currentPage: number;
+  categories: ClubCategorySummary[];
+  clubs: RecentClub[];
+}

--- a/apps/web/src/apis/recentClub/index.ts
+++ b/apps/web/src/apis/recentClub/index.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/apis/client';
+
+import type { RecentClubListRequestParams, RecentClubListResponse } from './entity';
+
+export const getRecentClubs = async (clubIds: number[]) => {
+  const response = await apiClient.get<RecentClubListResponse, RecentClubListRequestParams>('konect/clubs/recent', {
+    params: { clubIds },
+  });
+  return response;
+};

--- a/apps/web/src/apis/recentClub/queries.ts
+++ b/apps/web/src/apis/recentClub/queries.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { getRecentClubs } from '@/apis/recentClub';
+
+export const recentClubQueryKeys = {
+  all: ['recentClub'] as const,
+  list: (clubIds: number[]) => [...recentClubQueryKeys.all, 'list', ...clubIds] as const,
+};
+
+export const recentClubQueries = {
+  list: (clubIds: number[]) =>
+    queryOptions({
+      queryKey: recentClubQueryKeys.list(clubIds),
+      queryFn: () => getRecentClubs(clubIds),
+    }),
+};

--- a/apps/web/src/components/RecentClubSidebarSection.tsx
+++ b/apps/web/src/components/RecentClubSidebarSection.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@konect/utils/cn';
+import { Link } from 'react-router-dom';
+
+import type { RecentClub } from '@/apis/recentClub/entity';
+import { CATEGORY_TEXT_COLORS } from '@/constants/club';
+import { useRecentClubs } from '@/hooks/useRecentClubs';
+
+function RecentClubSidebarSection({ currentClubId }: { currentClubId?: number }) {
+  const { data } = useRecentClubs(currentClubId);
+  const recentClubs = data?.clubs ?? [];
+
+  return (
+    <section className="border-text-100 rounded-4xl border bg-white px-5 py-7 sm:rounded-[40px] sm:px-10 sm:py-11">
+      <h2 className="text-text-600 text-[24px] leading-10 font-medium">최근에 본 동아리</h2>
+      <div className="mt-10 flex flex-col gap-5">
+        {recentClubs.length > 0 ? (
+          recentClubs.map((club) => <RecentClubCard key={club.id} club={club} />)
+        ) : (
+          <p className="border-primary-200 text-text-400 bg-web-background rounded-[20px] border px-6 py-8 text-center text-[16px] leading-7">
+            표시할 동아리가 없어요.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function RecentClubCard({ club }: { club: RecentClub }) {
+  return (
+    <Link
+      className="border-primary-200 bg-web-background hover:border-primary-500 focus-visible:outline-primary-500 flex h-30.5 max-h-30.5 min-h-30.5 w-full shrink-0 items-center gap-7 overflow-hidden rounded-[20px] border px-7.5 py-6.5 text-left transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+      to={`/clubs/${club.id}`}
+    >
+      <ClubImage imageUrl={club.imageUrl} name={club.name} />
+      <span className="min-w-0">
+        <span className="block w-57 truncate text-[20px] leading-10 font-semibold text-black">{club.name}</span>
+        <span className="flex min-w-0 items-center gap-2 text-[16px] leading-10">
+          <span className={cn('shrink-0 font-semibold', CATEGORY_TEXT_COLORS[club.category])}>{club.categoryName}</span>
+          <span className="bg-text-200 size-1.5 shrink-0 rounded-full" aria-hidden="true" />
+          <span className="text-text-600 min-w-0 truncate font-medium">{club.topic || club.description}</span>
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function ClubImage({ imageUrl, name }: { imageUrl?: string; name: string }) {
+  if (imageUrl) {
+    return <img className="size-17.5 shrink-0 object-contain" src={imageUrl} alt="" />;
+  }
+
+  return (
+    <span className="bg-primary-100 border-primary-200 block size-17.5 shrink-0 rounded-full border">
+      <span className="sr-only">{name}</span>
+    </span>
+  );
+}
+
+export default RecentClubSidebarSection;

--- a/apps/web/src/hooks/useRecentClubIds.ts
+++ b/apps/web/src/hooks/useRecentClubIds.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+
+const RECENT_CLUB_IDS_STORAGE_KEY = 'konect:web:recent-club-ids:v1';
+const RECENT_CLUB_IDS_STORAGE_VERSION = 1;
+const RECENT_CLUB_IDS_CHANGE_EVENT = 'konect:recent-club-ids-change';
+const MAX_RECENT_CLUB_COUNT = 4;
+
+interface RecentClubIdsStorage {
+  version: typeof RECENT_CLUB_IDS_STORAGE_VERSION;
+  clubIds: number[];
+}
+
+function canUseLocalStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function sanitizeClubIds(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<number>();
+  const clubIds: number[] = [];
+  const rawClubIds: unknown[] = value;
+
+  for (const clubId of rawClubIds) {
+    if (typeof clubId !== 'number') continue;
+    if (!Number.isInteger(clubId) || clubId <= 0 || seen.has(clubId)) continue;
+
+    seen.add(clubId);
+    clubIds.push(clubId);
+
+    if (clubIds.length >= MAX_RECENT_CLUB_COUNT) break;
+  }
+
+  return clubIds;
+}
+
+export function getRecentClubIds() {
+  if (!canUseLocalStorage()) return [];
+
+  try {
+    const rawValue = window.localStorage.getItem(RECENT_CLUB_IDS_STORAGE_KEY);
+    if (!rawValue) return [];
+
+    const parsedValue: unknown = JSON.parse(rawValue);
+
+    if (Array.isArray(parsedValue)) {
+      return sanitizeClubIds(parsedValue);
+    }
+
+    if (
+      parsedValue &&
+      typeof parsedValue === 'object' &&
+      'version' in parsedValue &&
+      'clubIds' in parsedValue &&
+      parsedValue.version === RECENT_CLUB_IDS_STORAGE_VERSION
+    ) {
+      return sanitizeClubIds(parsedValue.clubIds);
+    }
+  } catch {
+    return [];
+  }
+
+  return [];
+}
+
+function setRecentClubIds(clubIds: number[]) {
+  if (!canUseLocalStorage()) return;
+
+  const nextValue: RecentClubIdsStorage = {
+    version: RECENT_CLUB_IDS_STORAGE_VERSION,
+    clubIds: sanitizeClubIds(clubIds),
+  };
+
+  try {
+    window.localStorage.setItem(RECENT_CLUB_IDS_STORAGE_KEY, JSON.stringify(nextValue));
+    window.dispatchEvent(new Event(RECENT_CLUB_IDS_CHANGE_EVENT));
+  } catch {
+    return;
+  }
+}
+
+export function addRecentClubId(clubId: number) {
+  if (!Number.isInteger(clubId) || clubId <= 0) return;
+
+  const previousClubIds = getRecentClubIds();
+  const nextClubIds = [clubId, ...previousClubIds.filter((previousClubId) => previousClubId !== clubId)];
+  setRecentClubIds(nextClubIds);
+}
+
+export function useRecentClubIds() {
+  const [clubIds, setClubIds] = useState(getRecentClubIds);
+
+  useEffect(() => {
+    if (!canUseLocalStorage()) return;
+
+    const updateClubIds = () => {
+      setClubIds(getRecentClubIds());
+    };
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === RECENT_CLUB_IDS_STORAGE_KEY) {
+        updateClubIds();
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    window.addEventListener(RECENT_CLUB_IDS_CHANGE_EVENT, updateClubIds);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(RECENT_CLUB_IDS_CHANGE_EVENT, updateClubIds);
+    };
+  }, []);
+
+  return clubIds;
+}

--- a/apps/web/src/hooks/useRecentClubs.ts
+++ b/apps/web/src/hooks/useRecentClubs.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { recentClubQueries } from '@/apis/recentClub/queries';
+import { useRecentClubIds } from '@/hooks/useRecentClubIds';
+
+const MAX_RECENT_CLUB_COUNT = 4;
+
+export function useRecentClubs(currentClubId?: number) {
+  const clubIds = useRecentClubIds();
+  const displayClubIds = useMemo(() => {
+    if (!currentClubId || !Number.isInteger(currentClubId) || currentClubId <= 0) return clubIds;
+
+    return [currentClubId, ...clubIds.filter((clubId) => clubId !== currentClubId)].slice(0, MAX_RECENT_CLUB_COUNT);
+  }, [clubIds, currentClubId]);
+
+  return useQuery({
+    ...recentClubQueries.list(displayClubIds),
+    enabled: displayClubIds.length > 0,
+  });
+}

--- a/apps/web/src/pages/ClubDetail/index.tsx
+++ b/apps/web/src/pages/ClubDetail/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { cn } from '@konect/utils/cn';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useParams } from 'react-router-dom';
@@ -6,7 +7,9 @@ import { clubDetailQueries } from '@/apis/clubDetail/queries';
 import AddMov from '@/assets/add-mov.svg';
 import AddPhoto from '@/assets/add-photo.svg';
 import NoneImage from '@/assets/None-image.png';
+import RecentClubSidebarSection from '@/components/RecentClubSidebarSection';
 import { CATEGORY_TEXT_COLORS } from '@/constants/club';
+import { addRecentClubId } from '@/hooks/useRecentClubIds';
 
 function Introduce({ introduce }: { introduce: string }) {
   return (
@@ -57,6 +60,10 @@ export default function ClubDetail() {
   const endDate = formatDate(clubDetail.recruitment.endAt);
   const recruitmentPeriod = startDate && endDate ? `${startDate}~${endDate}` : '미정';
 
+  useEffect(() => {
+    addRecentClubId(clubDetail.id);
+  }, [clubDetail.id]);
+
   return (
     <main className="bg-web-background min-h-screen text-black">
       <div className="mx-auto flex w-full max-w-369.5 flex-col px-5 pt-12 pb-20 sm:px-8 lg:pt-25.5 xl:px-0">
@@ -80,9 +87,7 @@ export default function ClubDetail() {
                 </div>
               </div>
             </section>
-            <section className="border-text-100 rounded-4xl border bg-white px-5 py-7 sm:rounded-[40px] sm:px-10 sm:py-11">
-              <h2 className="text-text-600 text-[24px] leading-10 font-medium">최근에 본 동아리</h2>
-            </section>
+            <RecentClubSidebarSection currentClubId={clubDetail.id} />
           </aside>
           <div className="flex flex-col gap-10">
             <section className="flex min-h-75 flex-col gap-[37.5px] rounded-4xl bg-white px-11 py-10">

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -5,10 +5,11 @@ import { Link } from 'react-router-dom';
 
 import type { Region, HomeRequestParams, University } from '@/apis/home/entity';
 import { homeQueries } from '@/apis/home/queries';
-import clubBadgeBlue from '@/assets/club-badge-blue.png';
-import clubBadgeRed from '@/assets/club-badge-red.png';
+import type { RecentClub } from '@/apis/recentClub/entity';
 import heroCatBook from '@/assets/hero-cat-book.png';
 import SearchIcon from '@/assets/svg/search-icon.svg';
+import { CATEGORY_TEXT_COLORS } from '@/constants/club';
+import { useRecentClubs } from '@/hooks/useRecentClubs';
 
 const REGION_OPTIONS: { label: string; value?: Region }[] = [
   { label: '전체' },
@@ -19,45 +20,6 @@ const REGION_OPTIONS: { label: string; value?: Region }[] = [
   { label: '경상도', value: 'GYEONGSANG' },
   { label: '강원도', value: 'GANGWON' },
   { label: '제주도', value: 'JEJU' },
-];
-
-type RecentClub = {
-  id: number;
-  name: string;
-  category: string;
-  keyword: string;
-  logo: string;
-};
-
-const recentClubs: RecentClub[] = [
-  {
-    id: 1,
-    name: '경영전략연구회',
-    category: '학술',
-    keyword: '경영',
-    logo: clubBadgeBlue,
-  },
-  {
-    id: 2,
-    name: '경영전략연구회',
-    category: '학술',
-    keyword: '경영',
-    logo: clubBadgeRed,
-  },
-  {
-    id: 3,
-    name: '경영전략연구회',
-    category: '학술',
-    keyword: '경영',
-    logo: clubBadgeBlue,
-  },
-  {
-    id: 4,
-    name: '경영전략연구회',
-    category: '학술',
-    keyword: '경영',
-    logo: clubBadgeBlue,
-  },
 ];
 
 function Home() {
@@ -75,7 +37,9 @@ function Home() {
   } satisfies HomeRequestParams;
 
   const { data: homeData } = useSuspenseQuery(homeQueries.detail(homeParams));
+  const { data: recentClubData } = useRecentClubs();
   const universities = homeData.universities ?? [];
+  const recentClubs = recentClubData?.clubs ?? [];
   const totalUniversityCount = homeData.totalUniversityCount;
   const isSearching = searchKeyword.trim().length > 0 || searchQuery.length > 0;
 
@@ -135,9 +99,11 @@ function Home() {
           <section className="min-h-0 overflow-hidden" aria-hidden={isSearching}>
             <SectionTitle title="최근에 본 동아리" description="관심있게 봤던 동아리를 다시 확인해보세요." />
             <div className="xl: mt-7 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {recentClubs.map((club) => (
-                <RecentClubCard key={club.id} club={club} />
-              ))}
+              {recentClubs.length > 0 ? (
+                recentClubs.map((club) => <RecentClubCard key={club.id} club={club} />)
+              ) : (
+                <RecentClubListMessage />
+              )}
             </div>
           </section>
         </div>
@@ -195,20 +161,34 @@ function SectionTitle({ title, description }: { title: string; description: stri
 
 function RecentClubCard({ club }: { club: RecentClub }) {
   return (
-    <button
+    <Link
       className="border-text-100 hover:border-primary-500 focus-visible:outline-primary-500 flex h-35 items-center gap-7 rounded-[20px] border bg-white px-5.5 py-8 transition-colors hover:shadow-[0_0_30px_0_rgba(105,191,223,0.30)] focus-visible:outline-2 focus-visible:outline-offset-2"
-      type="button"
+      to={`/clubs/${club.id}`}
     >
-      <img className="size-12.5 shrink-0 rounded-full object-cover" src={club.logo} alt="" />
+      {club.imageUrl ? (
+        <img className="size-12.5 shrink-0 rounded-full object-cover" src={club.imageUrl} alt="" />
+      ) : (
+        <span className="bg-primary-100 border-primary-200 block size-12.5 shrink-0 rounded-full border">
+          <span className="sr-only">{club.name}</span>
+        </span>
+      )}
       <span className="min-w-0">
         <span className="block truncate text-[20px] leading-10 font-semibold text-black">{club.name}</span>
         <span className="flex items-center gap-2 text-[14px] leading-10">
-          <span className="text-primary-600 font-semibold">{club.category}</span>
+          <span className={`${CATEGORY_TEXT_COLORS[club.category]} font-semibold`}>{club.categoryName}</span>
           <span className="bg-text-200 size-1.5 rounded-full" aria-hidden="true" />
-          <span className="text-text-600 font-medium">{club.keyword}</span>
+          <span className="text-text-600 min-w-0 truncate font-medium">{club.topic || club.description}</span>
         </span>
       </span>
-    </button>
+    </Link>
+  );
+}
+
+function RecentClubListMessage() {
+  return (
+    <div className="border-text-100 text-text-500 flex h-35 items-center justify-center rounded-[20px] border bg-white text-center text-[18px] leading-8 sm:col-span-2 lg:col-span-3 xl:col-span-4">
+      최근에 본 동아리가 없어요.
+    </div>
   );
 }
 

--- a/apps/web/src/pages/UniversityClubList/index.tsx
+++ b/apps/web/src/pages/UniversityClubList/index.tsx
@@ -7,6 +7,7 @@ import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom';
 import type { ClubCategory, UniversityClub, UniversityClubListRequestParams } from '@/apis/universityClub/entity';
 import { universityClubQueries } from '@/apis/universityClub/queries';
 import SearchIcon from '@/assets/svg/search-icon.svg';
+import RecentClubSidebarSection from '@/components/RecentClubSidebarSection';
 import { CATEGORY_TEXT_COLORS } from '@/constants/club';
 
 const PAGE_LIMIT = 12;
@@ -52,7 +53,6 @@ function UniversityClubListContent({ universityId }: { universityId: number }) {
   const universityLabel = university.campusName ? `${university.name} ${university.campusName}` : university.name;
   const categoryTotalCount = categories.reduce((sum, category) => sum + category.count, 0);
   const allClubCount = categoryTotalCount || totalCount;
-  const recentClubs = clubs.slice(0, 4);
 
   useEffect(() => {
     setSearchKeyword(query);
@@ -116,18 +116,7 @@ function UniversityClubListContent({ universityId }: { universityId: number }) {
               </div>
             </section>
 
-            <section className="border-text-100 rounded-4xl border bg-white px-5 py-7 sm:rounded-[40px] sm:px-10 sm:py-11">
-              <h2 className="text-text-600 text-[24px] leading-10 font-medium">최근에 본 동아리</h2>
-              <div className="mt-10 flex flex-col gap-5">
-                {recentClubs.length > 0 ? (
-                  recentClubs.map((club) => <RecentClubCard key={club.id} club={club} />)
-                ) : (
-                  <p className="border-primary-200 text-text-400 bg-web-background rounded-[20px] border px-6 py-8 text-center text-[16px] leading-7">
-                    표시할 동아리가 없어요.
-                  </p>
-                )}
-              </div>
-            </section>
+            <RecentClubSidebarSection />
           </aside>
 
           <section className="flex min-w-0 flex-col items-center gap-10">
@@ -193,24 +182,6 @@ function UniversityClubListContent({ universityId }: { universityId: number }) {
         </div>
       </div>
     </main>
-  );
-}
-
-function RecentClubCard({ club }: { club: UniversityClub }) {
-  return (
-    <Link
-      className="border-primary-200 bg-web-background hover:border-primary-500 focus-visible:outline-primary-500 flex h-30.5 max-h-30.5 min-h-30.5 w-full shrink-0 items-center gap-7 overflow-hidden rounded-[20px] border px-7.5 py-6.5 text-left transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
-      type="button"
-      to={`/clubs/${club.id}`}
-    >
-      <ClubImage className="size-17.5" imageUrl={club.imageUrl} name={club.name} />
-      <ClubMeta
-        club={club}
-        titleClassName="w-57 text-[20px]"
-        categoryClassName="text-[16px]"
-        descriptionClassName="text-[16px]"
-      />
-    </Link>
   );
 }
 


### PR DESCRIPTION
## ✨ 요약

```ts
- 최근 본 동아리 카드 조회 API와 React Query 옵션을 추가했습니다.
- 동아리 상세 진입 시 최근 본 동아리 ID를 로컬 스토리지에 최대 4개까지 저장하도록 구현했습니다.
- 홈/학교별 목록/상세 화면의 최근 본 동아리 영역을 실제 API 데이터로 연결했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #310

<br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 최근에 본 동아리 조회 기능 추가
  * 최근에 본 동아리를 로컬 저장소에 자동 기록
  * 홈 페이지, 동아리 상세 페이지, 동아리 목록 페이지에서 최근 본 동아리 섹션 표시
  * 최근 본 동아리 섹션을 재사용 가능한 사이드바 컴포넌트로 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KONECT_FRONT_END/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->