### PR TITLE
[fix] 웹 동아리 신청 API 및 상세 소개 UI 수정

### DIFF
--- a/apps/web/src/apis/clubInformationUpdate/index.ts
+++ b/apps/web/src/apis/clubInformationUpdate/index.ts
@@ -2,7 +2,7 @@ import { apiClient } from '../client';
 import type { ClubInformationUpdateRequest } from './entity';
 
 export const submitClubInformationUpdateRequest = async (clubId: number, body: ClubInformationUpdateRequest) => {
-  const response = await apiClient.post<null>(`clubs/${clubId}/information-update-requests`, {
+  const response = await apiClient.post<null>(`konect/clubs/${clubId}/information-update-requests`, {
     body,
   });
   return response;

--- a/apps/web/src/apis/clubRegistration/index.ts
+++ b/apps/web/src/apis/clubRegistration/index.ts
@@ -2,7 +2,7 @@ import { apiClient } from '../client';
 import type { ClubRegistrationRequest } from './entity';
 
 export const submitClubRegistrationRequest = async (body: ClubRegistrationRequest) => {
-  const response = await apiClient.post<null>('clubs/registration-requests', {
+  const response = await apiClient.post<null>('konect/clubs/registration-requests', {
     body,
   });
   return response;

--- a/apps/web/src/pages/ClubDetail/index.tsx
+++ b/apps/web/src/pages/ClubDetail/index.tsx
@@ -1,42 +1,21 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect } from 'react';
 import { cn } from '@konect/utils/cn';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
 import { clubDetailQueries } from '@/apis/clubDetail/queries';
 import NoneImage from '@/assets/None-image.png';
-import AddMovIcon from '@/assets/svg/add-mov-icon.svg';
-import AddPhotoIcon from '@/assets/svg/add-photo-icon.svg';
 import Breadcrumb from '@/components/Breadcrumb';
 import UniversityClubSidebar from '@/components/UniversityClubSidebar';
 import { CATEGORY_TEXT_COLORS } from '@/constants/club';
 import useResetScroll from '@/utils/hooks/useResetScroll';
 import { saveRecentClubId } from '@/utils/recentClubStorage';
 
-const INTRODUCE_MEDIA_ITEMS = [
-  { label: '활동 사진', icon: <AddPhotoIcon /> },
-  { label: '소개 영상', icon: <AddMovIcon /> },
-];
-
 function Introduce({ introduce }: { introduce: string }) {
   return (
     <div className="flex flex-col">
-      <div className="flex gap-5">
-        {INTRODUCE_MEDIA_ITEMS.map(({ label, icon }) => (
-          <IntroduceMediaCard key={label} icon={icon} label={label} />
-        ))}
-      </div>
       <span className="text-text-500 mt-2.5 leading-10 font-semibold">{introduce}</span>
     </div>
-  );
-}
-
-function IntroduceMediaCard({ icon, label }: { icon: ReactNode; label: string }) {
-  return (
-    <section className="border-primary-200 flex h-59.5 w-83.25 flex-col items-center justify-center rounded-[20px] border bg-[#F8FAFC]">
-      {icon}
-      <span className="text-text-400 text-[20px] leading-10">{label}</span>
-    </section>
   );
 }
 


### PR DESCRIPTION
## ✨ 요약

```ts
웹 동아리 등록 및 정보 수정 요청 API 경로에 konect prefix를 반영했습니다.
동아리 상세 페이지에서 아직 지원하지 않는 활동 사진 및 소개 영상 카드를 제거했습니다.
```

<br><br>

## 😎 해결한 이슈

- close #336

<br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 클럽 정보 업데이트 및 등록 요청 API 엔드포인트 경로를 업데이트했습니다.
  * 클럽 상세 페이지의 동아리 소개 UI를 단순화했습니다. 미디어 카드 관련 요소가 제거되고 소개 텍스트만 표시되도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->